### PR TITLE
Migrate to headless Chrome to be running with Capybara

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,5 +127,13 @@ inside dummy app.
 To be able to to run specs you need to create `/spec/dummy/.env.test` file and add there variables for database
 connection (see `spec/dummy/.env` as a template)
 
+`chromedriver` is required to run feature specs. You may find OS-specific instructions [here](https://sites.google.com/a/chromium.org/chromedriver/getting-started).
+For macOS it can be installed with Homebrew:
+
+```sh
+brew tap homebrew/cask
+brew cask install chromedriver
+```
+
 ## License
 The gem is available as open source under the terms of the [Apache License](https://github.com/learningtapestry/lcms-engine/blob/master/LICENSE).

--- a/lcms-engine.gemspec
+++ b/lcms-engine.gemspec
@@ -104,7 +104,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'will_paginate-bootstrap'
 
   s.add_development_dependency 'capybara-screenshot'
-  s.add_development_dependency 'capybara-webkit'
+  s.add_development_dependency 'capybara-selenium'
   s.add_development_dependency 'database_cleaner', '~> 1'
   s.add_development_dependency 'dotenv-rails', '~> 2.2'
   s.add_development_dependency 'email_spec', '~> 2.1'

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -124,7 +124,7 @@ feature 'Admin users' do
 
   def navigate_to_edit_user
     visit lcms_engine.admin_users_path
-    click_link user.id
+    click_link user.id.to_s
     expect(current_path).to eq lcms_engine.edit_admin_user_path(user.id)
   end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,17 +2,20 @@
 
 require 'capybara/rails'
 require 'capybara/rspec'
-require 'capybara-webkit'
 require 'capybara-screenshot/rspec'
+require 'selenium/webdriver'
 
-Capybara.javascript_driver = :webkit
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-  config.timeout = 20
-  config.ignore_ssl_errors
-  # NOTE: Do we need to raise them?
-  # config.raise_javascript_errors = true
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(disable-gpu headless no-sandbox) }
+  )
+  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome
 
 Capybara::Screenshot.prune_strategy = :keep_last_run


### PR DESCRIPTION
Webkit has Qt dependency which is tricky to install on different OS. Here we migrate to use Selenium webdriver to be used with headless Google Chrome.

To achieve that one needs to install `chromedriver` manually. How to do that can be found [here](https://sites.google.com/a/chromium.org/chromedriver/getting-started). To install on macOS:

```sh
brew tap homebrew/cask
brew cask install chromedriver
```