### PR TITLE
(openscied-lcms#334) Check&fix reimport with gdoc templates

### DIFF
--- a/app/services/lcms/engine/html_sanitizer.rb
+++ b/app/services/lcms/engine/html_sanitizer.rb
@@ -244,7 +244,7 @@ module Lcms
         def fix_table_styles(nodes, param, selector)
           attr_regex = /(^|;\s*)#{param}\s*:\s*([\w\.]+)\s*($|;)*/
           nodes.css(selector).each do |node|
-            node[param] = node['style'].match(attr_regex)[2]
+            node[param] = node['style'].match(attr_regex)&.[](2)
           end
         end
 


### PR DESCRIPTION
Fix for sanitizer: correctly handle the situation when there are no styled tables