### PR TITLE
Fix metadata table detection

### DIFF
--- a/lib/doc_template/tables/base.rb
+++ b/lib/doc_template/tables/base.rb
@@ -20,7 +20,8 @@ module DocTemplate
         @options = args.extract_options!
 
         # get the table
-        table = fragment.at_xpath("table//*[contains(., '#{self.class::HEADER_LABEL}')]")
+        table_key_cell = fragment.at_xpath("table//tr[1]/td[1][contains(., '#{self.class::HEADER_LABEL}')]")
+        table = table_key_cell&.ancestors('table')&.first
         @table_exists = table.present?
         return self unless @table_exists
 


### PR DESCRIPTION
The table is detected by a special keyword located in the very first cell of the first row. Otherwise, if the keyword is located inside any other table, then such a table will be treated like containing metadata.