### PR TITLE
(#35) Fix document creation inside Curriculum tree

### DIFF
--- a/spec/lib/lt/lcms/metadata/context_spec.rb
+++ b/spec/lib/lt/lcms/metadata/context_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ::Lt::Lcms::Metadata::Context do
+  shared_examples 'reordable' do |curriculum_type|
+    subject { described_class.send("update_#{curriculum_type}s_level_position_for", children) }
+
+    it "reorders #{curriculum_type}s" do
+      subject
+      expect(parent.reload.children.map(&:short_title)).to eq result
+    end
+  end
+
+  context '.update_grades_level_position_for' do
+    let(:parent) { build_or_return_resources_chain(['ela']) }
+    let!(:children) do
+      ['grade 11', 'grade 9', 'grade 10'].map do |grade|
+        create(:resource, :grade, parent: parent, short_title: grade)
+      end
+    end
+    let(:result) { ['grade 9', 'grade 10', 'grade 11'] }
+
+    include_examples 'reordable', 'grade'
+  end
+
+  context '.update_modules_level_position_for' do
+    let(:parent) { build_or_return_resources_chain(['ela', 'grade 1']) }
+    let!(:children) do
+      %w(m4 m3 m1 m2).map do |guidebook|
+        create(:resource, :module, parent: parent, short_title: guidebook)
+      end
+    end
+    let(:result) { %w(m1 m2 m3 m4) }
+
+    include_examples 'reordable', 'module'
+  end
+
+  context '.update_units_level_position_for' do
+    let(:parent) { build_or_return_resources_chain(['ela', 'grade 1', 'F1']) }
+    let!(:children) do
+      ['section 10', 'section 4', 'section 5'].map do |section|
+        create(:resource, curriculum_type: 'unit', parent: parent, short_title: section)
+      end
+    end
+    let(:result) { ['section 4', 'section 5', 'section 10'] }
+
+    include_examples 'reordable', 'unit'
+  end
+end

--- a/spec/support/resource_factory_helper.rb
+++ b/spec/support/resource_factory_helper.rb
@@ -55,6 +55,25 @@ module ResourceFactoryHelper
       parent = res
     end
   end
+
+  def build_or_return_resources_chain(curr)
+    dir = []
+    parent = nil
+    ::Lcms::Engine::Resource::HIERARCHY.each_with_index do |type, idx|
+      next unless curr[idx]
+
+      dir.push curr[idx]
+      res = ::Lcms::Engine::Resource.find_by(short_title: curr[idx]) ||
+            create(:resource,
+                   title: "Test Resource #{dir.join('|')}",
+                   short_title: curr[idx],
+                   curriculum_type: type,
+                   parent: parent,
+                   metadata: ::Lcms::Engine::Resource.metadata_from_dir(dir))
+      parent = res
+    end
+    parent
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Refs #35 

- Correctly create document inside Curriculum tree
- Introduce separate helpers to `Resource` model to update the resources and their order