### PR TITLE
Allows create resources of type `subject` with lesson import

### DIFF
--- a/app/controllers/lcms/engine/admin/resource_picker_controller.rb
+++ b/app/controllers/lcms/engine/admin/resource_picker_controller.rb
@@ -28,7 +28,7 @@ module Lcms
             index_p = default_params.merge(expected_params)
 
             grade_ok = index_p[:grade].blank? || Filterbar::GRADES.include?(index_p[:grade])
-            type_ok = index_p[:type].blank? || Resource::HIERARCHY.include?(index_p[:type].to_sym)
+            type_ok = index_p[:type].blank? || Resource.hierarchy.include?(index_p[:type].to_sym)
             subject_ok = index_p[:subject].blank? || Resource::SUBJECTS.include?(index_p[:subject])
 
             raise StandardError unless grade_ok && type_ok && subject_ok

--- a/app/entities/lcms/engine/breadcrumbs.rb
+++ b/app/entities/lcms/engine/breadcrumbs.rb
@@ -10,14 +10,14 @@ module Lcms
       end
 
       def full_title
-        hierarchy.map do |key|
+        Lcms::Engine::Resource.hierarchy.map do |key|
           val = resource.metadata[key.to_s]
           key == :subject ? val&.upcase : val&.humanize
         end.compact.join(' / ')
       end
 
       def pieces
-        hierarchy.map do |key|
+        Lcms::Engine::Resource.hierarchy.map do |key|
           if resource.curriculum_type&.to_sym == key
             value = resource.metadata[key.to_s]
             value.match?(/topic/i) ? value.upcase.sub('TOPIC', 'topic') : value
@@ -28,7 +28,7 @@ module Lcms
       end
 
       def short_pieces
-        hierarchy.map { |key| send(:"#{key}_abbrv", short: true) }.compact
+        Lcms::Engine::Resource.hierarchy.map { |key| send(:"#{key}_abbrv", short: true) }.compact
       end
 
       def short_title
@@ -41,10 +41,6 @@ module Lcms
       end
 
       private
-
-      def hierarchy
-        Resource::HIERARCHY
-      end
 
       def subject_abbrv(short: false)
         if short

--- a/app/entities/lcms/engine/curriculum_map.rb
+++ b/app/entities/lcms/engine/curriculum_map.rb
@@ -42,7 +42,7 @@ module Lcms
                   .take
         CurriculumResourceSerializer.new(
           grade,
-          depth: full_depth? ? Resource::HIERARCHY.size : 1,
+          depth: full_depth? ? Resource.hierarchy.size : 1,
           depth_branch: active_branch + target_branch
         ).as_json
       end

--- a/app/interactors/lcms/engine/explore_curriculum_interactor.rb
+++ b/app/interactors/lcms/engine/explore_curriculum_interactor.rb
@@ -44,7 +44,7 @@ module Lcms
         raise "Unknown Resource slug value: '#{slug_param}'" unless target
 
         grade = target.parents.detect(&:grade?)
-        depth = Resource::HIERARCHY.index(target.curriculum_type.to_sym)
+        depth = Resource.hierarchy.index(target.curriculum_type.to_sym)
 
         # self and ancestors, except the subject
         active_branch = target.self_and_ancestors.reject(&:subject?).map(&:id).reverse

--- a/app/models/lcms/engine/resource.rb
+++ b/app/models/lcms/engine/resource.rb
@@ -87,7 +87,7 @@ module Lcms
         end
 
         def metadata_from_dir(dir)
-          pairs = HIERARCHY[0...dir.size].zip(dir)
+          pairs = hierarchy[0...dir.size].zip(dir)
           Hash[pairs].compact.stringify_keys
         end
 
@@ -95,7 +95,7 @@ module Lcms
           dir = dir&.flatten&.select(&:present?)
           return unless dir.present?
 
-          type = HIERARCHY[dir.size - 1]
+          type = hierarchy[dir.size - 1]
           meta = metadata_from_dir(dir).to_json
           where('metadata @> ?', meta).where(curriculum_type: type).first
         end
@@ -107,6 +107,10 @@ module Lcms
         def find_video_by_url(url)
           video_id = MediaEmbed.video_id(url)
           video.where("url ~ '#{video_id}(&|$)'").first
+        end
+
+        def hierarchy
+          Lcms::Engine::Resource::HIERARCHY
         end
 
         # used for ransack search on the admin
@@ -171,7 +175,7 @@ module Lcms
       end
 
       def directory
-        @directory ||= HIERARCHY.map do |key|
+        @directory ||= Lcms::Engine::Resource.hierarchy.map do |key|
           key == :grade ? grades.average(abbr: false) : metadata[key.to_s]
         end.compact
       end
@@ -259,8 +263,8 @@ module Lcms
       end
 
       def next_hierarchy_level
-        index = HIERARCHY.index(curriculum_type.to_sym)
-        HIERARCHY[index + 1]
+        index = Lcms::Engine::Resource.hierarchy.index(curriculum_type.to_sym)
+        Lcms::Engine::Resource.hierarchy[index + 1]
       end
 
       def unit_bundles?

--- a/app/presenters/lcms/engine/curriculum_presenter.rb
+++ b/app/presenters/lcms/engine/curriculum_presenter.rb
@@ -4,7 +4,7 @@ module Lcms
   module Engine
     # Simple presenter for Curriculum (resources tree)
     class CurriculumPresenter
-      UNIT_LEVEL = Resource::HIERARCHY.index(:unit)
+      UNIT_LEVEL = Lcms::Engine::Resource.hierarchy.index(:unit)
 
       def editor_props
         @editor_props ||= {
@@ -23,7 +23,7 @@ module Lcms
       def opened?(node)
         return false if node.curriculum_type.blank?
 
-        level = Resource::HIERARCHY.index(node.curriculum_type.to_sym)
+        level = Lcms::Engine::Resource.hierarchy.index(node.curriculum_type.to_sym)
         level < UNIT_LEVEL
       end
 

--- a/app/views/lcms/engine/admin/resources/_fields.html.erb
+++ b/app/views/lcms/engine/admin/resources/_fields.html.erb
@@ -10,7 +10,7 @@
 
 <%= f.input :tree, label: 'Belongs to Curriculum Tree?', as: :boolean %>
 
-<%= f.input :curriculum_type, as: :select, collection: Lcms::Engine::Resource::HIERARCHY %>
+<%= f.input :curriculum_type, as: :select, collection: Lcms::Engine::Resource.hierarchy %>
 
 <%= f.input :opr_description, label: t('lcms.engine.admin.resources.form.opr_description'), wrapper_html: {class: (resource.unit? ? '': 'c-hidden')} %>
 

--- a/lib/lcms/engine/test/resource_helpers.rb
+++ b/lib/lcms/engine/test/resource_helpers.rb
@@ -45,7 +45,7 @@ module Lcms
         def build_resources_chain(curr)
           dir = []
           parent = nil
-          ::Lcms::Engine::Resource::HIERARCHY.each_with_index do |type, idx|
+          ::Lcms::Engine::Resource.hierarchy.each_with_index do |type, idx|
             next unless curr[idx]
 
             dir.push curr[idx]
@@ -62,7 +62,7 @@ module Lcms
         def build_or_return_resources_chain(curr)
           dir = []
           parent = nil
-          ::Lcms::Engine::Resource::HIERARCHY.each_with_index do |type, idx|
+          ::Lcms::Engine::Resource.hierarchy.each_with_index do |type, idx|
             next unless curr[idx]
 
             dir.push curr[idx]

--- a/lib/lt/lcms/metadata/context.rb
+++ b/lib/lt/lcms/metadata/context.rb
@@ -42,11 +42,12 @@ module Lt
           # been created after higher ones: Grade 8 was created before Grade 7
           #
           def update_level_position_for(resources)
-            resources.map { |m| { id: m.id, idx: yield(m) } }
+            resources
+              .map { |m| { id: m.id, idx: yield(m) } }
               .sort_by { |a| a[:idx] }.each_with_index do |data, idx|
-              resource = ::Lcms::Engine::Resource.find(data[:id])
-              resource.update_columns(level_position: idx) unless resource.level_position == idx
-            end
+                resource = ::Lcms::Engine::Resource.find(data[:id])
+                resource.update_columns(level_position: idx) unless resource.level_position == idx
+              end
           end
         end
 
@@ -117,11 +118,12 @@ module Lt
 
         def build_new_resource(parent, name, index)
           dir = directory[0..index]
+          curriculum_type = parent.nil? ? Lcms::Engine::Resource.hierarchy.first : parent.next_hierarchy_level
           resource = ::Lcms::Engine::Resource.new(
-            curriculum_type: parent.next_hierarchy_level,
-            level_position: parent.children.size,
+            curriculum_type: curriculum_type,
+            level_position: parent&.children&.size.to_i,
             metadata: metadata,
-            parent_id: parent.id,
+            parent_id: parent&.id,
             resource_type: :resource,
             short_title: name,
             curriculum_id: ::Lcms::Engine::Curriculum.default.id


### PR DESCRIPTION
Also, wraps all the calls to `Lcms::Engine::Resource::HIERARCHY` to the method to allow altering the hierarchy from inside the host application.