### PR TITLE
Upgrade `rubyzip` gem to avoid security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,6 @@ gemspec
 
 gem 'lt-lcms', git: 'https://github.com/learningtapestry/lt-lcms.git',
                branch: 'master',
-               ref: 'e0816d56'
+               ref: '4aac707'
 gem 'wicked_pdf', git: 'https://github.com/learningtapestry/wicked_pdf.git',
                   branch: 'puppeteer-support', ref: '67f73d3'

--- a/lcms-engine.gemspec
+++ b/lcms-engine.gemspec
@@ -90,7 +90,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'resque-scheduler'
   s.add_dependency 'rest-client', '~> 1.8'
   s.add_dependency 'ruby-progressbar', '~> 1.7', '>= 1.7.5'
-  s.add_dependency 'rubyzip', '~> 1.2.1'
+  s.add_dependency 'rubyzip', '>= 1.3.0'
   s.add_dependency 'sanitize', '~> 5.0'
   s.add_dependency 'sass-rails', '~> 5.0'
   s.add_dependency 'simple_form', '~> 3.5'


### PR DESCRIPTION
The [vulnerabality](https://github.com/learningtapestry/lcms-engine/network/alert/lcms-engine.gemspec/rubyzip/closed)