### PR TITLE
Base metadata refactoring

### DIFF
--- a/app/javascript/components/admin/ImportStatus.jsx
+++ b/app/javascript/components/admin/ImportStatus.jsx
@@ -7,7 +7,12 @@ class ImportStatus extends React.Component {
     this.pollingInterval = 5000
     this.chunkSize = 50
     this.links = _.isEmpty(props.links) ? [`${props.type}/:id`] : props.links
-    this.path = _.isEmpty(props.path) ? `/admin/${this.props.type}/import_status` : props.path
+    if (_.isEmpty(props.path)) {
+      const k = `lcms_engine_import_status_admin_${this.props.type}_path`
+      this.path = Routes[k].call()
+    } else {
+      this.path = props.path
+    }
     this.withPdf = props.with_pdf || false
   }
 

--- a/app/javascript/components/admin/MultiSelectedOperation.jsx
+++ b/app/javascript/components/admin/MultiSelectedOperation.jsx
@@ -24,7 +24,7 @@ class MultiSelectedOperation extends React.Component {
     const method = (this.props.operation === 'delete') ? 'delete' : 'post'
     const csrf_token = $('meta[name=csrf-token]').attr('content')
     return (
-      <form ref={ ref => { this.formRef = ref }} action={this.props.path} acceptCharset="UTF-8" method='post' className="c-reimport-doc-form" onSubmit={this.onSubmit} >
+      <form ref={ ref => { this.formRef = ref }} action={this.props.path} acceptCharset="UTF-8" method='post' className="c-reimport-doc-form" onSubmit={this.onSubmit.bind(this)} >
         <input name="utf8" value="✓" type="hidden" />
         <input name="_method" value={method} type="hidden" />
         <input name="authenticity_token" value={csrf_token} type="hidden" />

--- a/app/views/lcms/engine/admin/batch_reimports/import.html.erb
+++ b/app/views/lcms/engine/admin/batch_reimports/import.html.erb
@@ -6,5 +6,5 @@
   <div class="row">
     <%= link_to '<- Back', new_admin_batch_reimport_path(query: @query.to_h), class: 'button primary' %>
   </div>
-  <%= react_component('ImportStatus', @props) %>
+  <%= react_component('admin/ImportStatus', @props) %>
 </div>

--- a/app/views/lcms/engine/admin/documents/import.html.erb
+++ b/app/views/lcms/engine/admin/documents/import.html.erb
@@ -7,5 +7,5 @@
     <%= link_to '<- Back', admin_documents_path, class: 'button primary' %>
   </div>
 
-  <%= react_component('ImportStatus', @props) %>
+  <%= react_component('admin/ImportStatus', @props) %>
 </div>

--- a/app/views/lcms/engine/admin/materials/import.html.erb
+++ b/app/views/lcms/engine/admin/materials/import.html.erb
@@ -7,5 +7,5 @@
     <%= link_to '<- Back', admin_materials_path, class: 'button primary' %>
   </div>
 
-  <%= react_component('ImportStatus', @props) %>
+  <%= react_component('admin/ImportStatus', @props) %>
 </div>

--- a/lib/doc_template/objects/base_metadata.rb
+++ b/lib/doc_template/objects/base_metadata.rb
@@ -24,9 +24,24 @@ module DocTemplate
       attribute :type, String, default: 'core'
       attribute :unit, String, default: ''
 
-      def self.build_from(data)
-        copy = data&.transform_keys { |k| k.to_s.underscore }
-        new(copy.presence || {})
+      class << self
+        def build_from(data)
+          copy = data&.transform_keys { |k| k.to_s.underscore }
+          new(copy.presence || {})
+        end
+
+        #
+        # Splits the text by separator removing empty parts
+        #
+        # @param text [String] text to be split
+        # @param separator [String]
+        # @return [Array] array of parts
+        #
+        def split_field(text, separator = DocTemplate::Tables::Base::SPLIT_REGEX)
+          text.to_s
+            .split(separator)
+            .map(&:squish).reject(&:blank?)
+        end
       end
     end
   end

--- a/spec/lib/doc_template/objects/base_metadata_spec.rb
+++ b/spec/lib/doc_template/objects/base_metadata_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DocTemplate::Objects::BaseMetadata do
+  describe '.split_field' do
+    let(:content) { parts.join separator }
+    let(:parts) { %w(a b c d e) }
+    let(:separator) { '-' }
+
+    subject { described_class.split_field content, separator }
+
+    it 'returns splitted string' do
+      expect(subject).to eq parts
+    end
+  end
+end

--- a/spec/lib/doc_template/tables/base_spec.rb
+++ b/spec/lib/doc_template/tables/base_spec.rb
@@ -1,8 +1,27 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sanitize'
 
 describe DocTemplate::Tables::Base do
+  let(:html) { "<p><span>[#{DocTemplate::Tags::DefaultTag::TAG_NAME}]</span></p>" }
+  let(:html_rendered) { 'rendered tags' }
+
+  describe '#collect_and_render_tags' do
+    let(:data) { { 'field' => "[#{DocTemplate::Tags::DefaultTag::TAG_NAME}]" } }
+    let(:fields) { %w(field) }
+    let(:opts) { { keep_elements: %w(a i), separator: ',' } }
+
+    subject { described_class.new.collect_and_render_tags data, fields, opts }
+
+    it 'prepares the tag to render correctly' do
+      expect(Nokogiri::HTML).to receive(:fragment).with(html).and_return(Nokogiri::HTML.fragment(html))
+      expect(DocTemplate::Document).to receive_message_chain(:parse, :render).and_return(html_rendered)
+      expect(::Sanitize).to receive(:fragment).with(html_rendered, elements: opts[:keep_elements]).and_return('')
+      subject
+    end
+  end
+
   describe '#fetch_materials' do
     subject { described_class.new.fetch_materials(data, 'materials') }
 
@@ -43,6 +62,26 @@ describe DocTemplate::Tables::Base do
         subject
         expect(data['material_ids']).to be_empty
       end
+    end
+  end
+
+  describe '#parse_in_context' do
+    let(:contexts) { DocTemplate::DEFAULTS[:context_types] }
+    let(:metadata) { ::DocTemplate::Objects::BaseMetadata.new }
+    let(:opts) { { explicit_render: false, metadata: metadata } }
+
+    subject { described_class.new.parse_in_context html, opts }
+
+    it 'calls renders the tag for each context type' do
+      contexts.each do |context|
+        opts[:context_type] = context
+        doc = double DocTemplate::Document
+        expect(DocTemplate::Document).to receive(:parse)
+                                           .with(instance_of(Nokogiri::HTML::DocumentFragment), opts)
+                                           .and_return(doc)
+        expect(doc).to receive(:render).and_return(html_rendered)
+      end
+      subject
     end
   end
 end


### PR DESCRIPTION
- Add new collect_and_render_tags

Introduce new `DocTemplate::Tables::Base#collect_and_render_tags` method which can be used to fetch a list of tags from a metadata table row, and correctly parse each of these tags.

- Add `Tables::Base#parse_in_context`

Used when we need to parse the content and render tags in the context environment

- Add `BaseMetadata.split_field`

Simple field splitter with a specified separator