### PR TITLE
Allow customize AdminQuery objects

### DIFF
--- a/app/controllers/lcms/engine/admin/batch_reimports_controller.rb
+++ b/app/controllers/lcms/engine/admin/batch_reimports_controller.rb
@@ -11,9 +11,9 @@ module Lcms
         def create
           @query = OpenStruct.new params[:query].except(:type)
           entries = if materials?
-                      AdminMaterialsQuery.call(@query)
+                      DocTemplate.config['queries']['material'].constantize.call(@query)
                     else
-                      AdminDocumentsQuery.call(@query)
+                      DocTemplate.config['queries']['document'].constantize.call(@query)
                     end
           bulk_import entries
           render :import

--- a/app/controllers/lcms/engine/admin/documents_controller.rb
+++ b/app/controllers/lcms/engine/admin/documents_controller.rb
@@ -13,7 +13,7 @@ module Lcms
 
         def index
           @query = OpenStruct.new(params[:query])
-          @documents = AdminDocumentsQuery.call(@query, page: params[:page])
+          @documents = DocTemplate.config['queries']['document'].constantize.call(@query, page: params[:page])
           render_customized_view
         end
 

--- a/app/controllers/lcms/engine/admin/materials_controller.rb
+++ b/app/controllers/lcms/engine/admin/materials_controller.rb
@@ -11,7 +11,7 @@ module Lcms
 
         def index
           @query = OpenStruct.new params[:query]
-          @materials = AdminMaterialsQuery.call(@query, page: params[:page])
+          @materials = DocTemplate.config['queries']['material'].constantize.call(@query, page: params[:page])
           render_customized_view
         end
 

--- a/lib/doc_template.rb
+++ b/lib/doc_template.rb
@@ -12,6 +12,10 @@ module DocTemplate
       context: 'Lt::Lcms::Metadata::Context',
       service: 'Lt::Lcms::Metadata::Service'
     },
+    queries: {
+      document: 'Lcms::Engine::AdminDocumentsQuery',
+      material: 'Lcms::Engine::AdminMaterialsQuery'
+    },
     sanitizer: 'Lcms::Engine::HtmlSanitizer'
   }.freeze
 
@@ -30,6 +34,10 @@ module DocTemplate
   config['metadata'] ||= {}
   config['metadata']['context'] ||= DEFAULTS[:metadata][:context]
   config['metadata']['service'] ||= DEFAULTS[:metadata][:service]
+
+  config['queries'] ||= {}
+  config['queries']['document'] ||= DEFAULTS[:queries][:document]
+  config['queries']['material'] ||= DEFAULTS[:queries][:material]
 
   config['sanitizer'] ||= DEFAULTS[:sanitizer]
 


### PR DESCRIPTION
Query objects should be defined in `config/lcms.yml` file

```yaml
queries:
  document: 'AdminDocumentsQuery'
```