### PR TITLE
Fix metadata creation

### DIFF
--- a/app/controllers/lcms/engine/admin/batch_reimports_controller.rb
+++ b/app/controllers/lcms/engine/admin/batch_reimports_controller.rb
@@ -27,7 +27,7 @@ module Lcms
             job_id = job_class.perform_later(doc).job_id
             jobs[job_id] = { link: doc.file_url, status: 'waiting' }
           end
-          @props = { jobs: jobs, type: params.dig(:query, :type), links: [] }
+          @props = { jobs: jobs, type: params.dig(:query, :type), links: view_links }
         end
 
         def job_class

--- a/app/views/lcms/engine/admin/documents/index.html.erb
+++ b/app/views/lcms/engine/admin/documents/index.html.erb
@@ -44,7 +44,7 @@
           <td><%= check_box_tag 'selected_ids[]', lesson.id, selected_id?(lesson.id), class: 'c-selected-ids' %></td>
           <td class="u-text--right"><%= lesson.id %></td>
           <td><%= Lcms::Engine::Breadcrumbs.new(lesson.resource).short_title if lesson.resource %></td>
-          <td><%= link_to lesson&.resource&.title, ::Lcms::Engine::Admin::AdminController.document_path(lesson, request.query_parameters), target: '_blank' %></td>
+          <td><%= link_to lesson.resource&.title, ::Lcms::Engine::Admin::AdminController.document_path(lesson, request.query_parameters), target: '_blank' %></td>
           <td>
             <% if lesson.math? %>
               <% if lesson.file_url.present? %>

--- a/lib/lt/lcms/metadata/context.rb
+++ b/lib/lt/lcms/metadata/context.rb
@@ -118,11 +118,11 @@ module Lt
 
         def build_new_resource(parent, name, index)
           dir = directory[0..index]
-          curriculum_type = parent.nil? ? Lcms::Engine::Resource.hierarchy.first : parent.next_hierarchy_level
+          curriculum_type = parent.nil? ? ::Lcms::Engine::Resource.hierarchy.first : parent.next_hierarchy_level
           resource = ::Lcms::Engine::Resource.new(
             curriculum_type: curriculum_type,
             level_position: parent&.children&.size.to_i,
-            metadata: metadata,
+            metadata: metadata.to_a[0..index].to_h,
             parent_id: parent&.id,
             resource_type: :resource,
             short_title: name,


### PR DESCRIPTION
- When creating `Resource` it stores metadata for the current level only
- Minor refactoring
- Allows to override links to lessons after batch reimport

Need to specify in `lcms-admin.yml`:

```yaml
batch_reimports:
  view_links:
    - '/redirect-to-lesson/:id'
```