### PR TITLE
Fix parse loop when content of the tag  contains tag name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/learningtapestry/lcms-engine/compare/v0.1.0...HEAD)
 
+### Added
 - Add Docker support [@paranoicsan](https://github.com/paranoicsan)
+
+### Changed
+- Assets optimization [@paranoicsan](https://github.com/paranoicsan)
+
+### Fixed
+- Fix parse loop when content of the tag  contains tag name [@paranoicsan](https://github.com/paranoicsan)
+- Fix possible grade leading zeros [@shlag3n](https://github.com/shlag3n)
+- Fix nested jobs concern [@shlag3n](https://github.com/shlag3n)
 
 ## [0.1.0] - 2020.01.13
 

--- a/lib/doc_template/tags/base_tag.rb
+++ b/lib/doc_template/tags/base_tag.rb
@@ -16,7 +16,7 @@ module DocTemplate
         def tag_with_html_regexp
           raise NotImplementedError unless const_defined?(:TAG_NAME)
 
-          @tag_with_html_regexp ||= /\[[^\]]*#{self::TAG_NAME}[[^\:]]*:?\s?[^\]]*\]/i
+          @tag_with_html_regexp ||= /\[[^\]]*#{self::TAG_NAME}[[^\:,;.]]*:?\s?[^\]]*\]/i
         end
 
         def template_path_for(name)

--- a/spec/lib/doc_template/tags/base_tag_spec.rb
+++ b/spec/lib/doc_template/tags/base_tag_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal:true
+
+require 'rails_helper'
+
+class BaseSpecTag < DocTemplate::Tags::BaseTag
+  TAG_NAME = 'image'
+end
+
+describe ::DocTemplate::Tags::BaseTag do
+  describe '.tag_with_html_regexp' do
+    let(:content) do
+      <<~HTML
+        <p style='padding:0;font-size:11pt;font-family:\"Arial\";line-height:1.5;text-align:left'><span style='
+        vertical-align:baseline;font-size:11pt;font-family:\"Cabin\";'>[image:OP.PT.L13.014, 50, Esta imagen
+        muestra ruedas de carretas que han sido enterradas por la tierra movida por el viento durante una
+        tormenta de polvo.] Los Estados Unidos tienen una historia trágica con sedimentos en movimiento por el viento
+        Durante la década de 1930, gran parte de los Estados Unidos estaba pasando por una sequía.</span></p>
+      HTML
+    end
+
+    subject { BaseSpecTag.tag_with_html_regexp }
+
+    it 'returns RegExp for a single match only' do
+      data = subject.match(content)
+      expect(data.size).to eq 1
+    end
+
+    context 'when TAG_NAME is not defined' do
+      before { BaseSpecTag.send :remove_const, :TAG_NAME }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Occurs when tag has content with a word matching tag's name and complex styling:

> <p style='padding:0;font-size:11pt;font-family:\"Arial\";line-height:1.5;text-align:left'><span style='vertical-align:baseline;font-size:11pt;font-family:\"Cabin\";'>[image:OP.PT.L13.014, 50, Esta imagen muestra ruedas de carretas que han sido enterradas por la tierra movida por el viento durante una tormenta de polvo.] Los Estados Unidos tienen una historia trágica con sedimentos en movimiento por el viento. Durante la década de 1930, gran parte de los Estados Unidos estaba pasando por una sequía. La falta de agua hizo que el suelo se volviera seco, suelto y polvoriento. La sequía hizo que el suelo se aflojara, ya que había poca agua en la capa superior del suelo, arena y arcilla para mantenerla unida. El resultado fueron enormes nubes de polvo que se formaron a partir del viento que soplaba sobre la tierra seca de las Grandes Llanuras y el Medio Oeste. Estas nubes de polvo a menudo se denominaban \"tormentas de nieve negras\". Los agricultores tuvieron dificultades para plantar cultivos, y murieron personas y ganado. Esto sucedió durante la Gran Depresión y empeoró las condiciones durante ese tiempo. El Dust Bowl movió muchos sedimentos. Los relatos históricos muestran que solo de una tormenta, más de 12 millones de libras de tierra vegetal fueron transportadas hacia el este desde los estados de Dakota del Norte, Dakota del Sur y Nebraska hasta Chicago. Algunos sedimentos llegaron incluso a Boston y Nueva York. La tormenta incluso hizo que cayera nieve roja en Nueva Inglaterra. Esta área no es tan seca ahora, pero es un recordatorio para todos nosotros de tener cuidado con las sequías, el cultivo excesivo y el viento.  </span></p>