### PR TITLE
Fix preview path on admin panel index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Assets optimization [@paranoicsan](https://github.com/paranoicsan)
 
 ### Fixed
+- Fix preview path on admin panel documents and materials index page [@paranoicsan](https://github.com/paranoicsan)
 - Fix parse loop when content of the tag  contains tag name [@paranoicsan](https://github.com/paranoicsan)
 - Fix possible grade leading zeros [@shlag3n](https://github.com/shlag3n)
 - Fix nested jobs concern [@shlag3n](https://github.com/shlag3n)

--- a/app/controllers/lcms/engine/admin/admin_controller.rb
+++ b/app/controllers/lcms/engine/admin/admin_controller.rb
@@ -25,11 +25,11 @@ module Lcms
           end
 
           def document_path(*args)
-            host_engine_path(:document_path, args).presence || url_helpers.document_path(args)
+            host_engine_path(:document_path, *args).presence || url_helpers.document_path(*args)
           end
 
           def material_path(*args)
-            host_engine_path(:material_path, args).presence || url_helpers.material_path(args)
+            host_engine_path(:material_path, *args).presence || url_helpers.material_path(*args)
           end
 
           def root_path
@@ -38,9 +38,9 @@ module Lcms
 
           def host_engine_path(key, *args)
             if (host_route = settings.dig(:redirect, :host, key)).present?
-              Rails.application.routes.url_helpers.send(host_route, args)
+              Rails.application.routes.url_helpers.send(host_route, *args)
             elsif (engine_route = settings.dig(:redirect, :engine, key)).present?
-              engine_klass.routes.url_helpers.send(engine_route, args)
+              engine_klass.routes.url_helpers.send(engine_route, *args)
             end
           end
 

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lcms::Engine::Admin::AdminController do
+  describe '.host_engine_path' do
+    let(:args) { { query: 'test', filter: '1' } }
+
+    subject { described_class.host_engine_path(:root_path, args) }
+
+    context 'with host redirect' do
+      it 'builds correct path' do
+        expect(subject).to eq "/admin?#{args.to_param}"
+      end
+    end
+
+    context 'with engine redirect' do
+      let(:settings) do
+        settings = described_class.settings
+        settings[:redirect].delete(:host)
+        settings
+      end
+
+      before { allow(described_class).to receive(:settings).and_return(settings) }
+
+      it 'builds correct path' do
+        expect(subject).to eq "/lcms-engine/admin?#{args.to_param}"
+      end
+    end
+  end
+end

--- a/spec/dummy/config/lcms-admin.yml
+++ b/spec/dummy/config/lcms-admin.yml
@@ -10,12 +10,12 @@ engine: 'Lcms::Engine::Engine'
 # Redirects
 redirect:
   host:
-    # TODO: Check the handle of chained path here
     root_path: 'admin_path'
-  engine:
-    # TODO: Check the handle of chained path here
     document_path: 'document_path'
-    # TODO: Check the handle of chained path here
+    material_path: 'material_path'
+  engine:
+    root_path: 'admin_path'
+    document_path: 'document_path'
     material_path: 'material_path'
 
 # TODO: Check the default values handling

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,4 +3,6 @@
 Rails.application.routes.draw do
   mount Lcms::Engine::Engine => '/lcms-engine'
   root to: redirect('/lcms-engine/')
+
+  get '/admin', to: 'welcome#index', as: :admin
 end


### PR DESCRIPTION
Fix behavior when preview link is broken for `Document` and `Material` objects inside Admin panel.