### PR TITLE
Take TEXT elements into consideration while stripping content

### DIFF
--- a/app/services/lcms/engine/html_sanitizer.rb
+++ b/app/services/lcms/engine/html_sanitizer.rb
@@ -10,7 +10,7 @@ module Lcms
       GDOC_REMOVE_EMPTY_SELECTOR = '.o-ld-activity'
       LINK_UNDERLINE_REGEX = /text-decoration\s*:\s*underline/i
       SKIP_P_CHECK = %w(ul ol table).freeze
-      STRIP_ELEMENTS = %w(a div h1 h2 h3 h4 h5 h6 p span table).freeze
+      STRIP_ELEMENTS = %w(a div h1 h2 h3 h4 h5 h6 p span table text).freeze
 
       class << self
         def clean_content(html, context_type)
@@ -35,7 +35,7 @@ module Lcms
         # Removes all empty nodes before first one filled in
         #
         def strip_content(nodes)
-          nodes.xpath('./*').each do |node|
+          nodes.children.each do |node|
             break if keep_node?(node)
 
             node.remove

--- a/spec/services/html_sanitizer_spec.rb
+++ b/spec/services/html_sanitizer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 describe Lcms::Engine::HtmlSanitizer do
   describe '.sanitize' do
     subject { described_class.sanitize(html) }
@@ -175,6 +177,38 @@ describe Lcms::Engine::HtmlSanitizer do
           expect(subject.scan('<p>').size).to eq 5
         end
       end
+    end
+  end
+
+  describe '.strip_content' do
+    let(:html_clean) do
+      <<~HTML
+        {{inset_392e9effbf43oi988b8c}}
+        <p></p>
+        <h3 style="text-align:left;">
+          <span style="font-style:italic">In place of a semicolon</span><span>: The use of an em dash here is to create overwhelming emphasis or pause to influence shock and awe in your readers. </span>
+        </h3>
+        <p></p>
+        {{inset_392e9effbf47d0988b8c}}
+        <p></p>
+      HTML
+    end
+    let(:html) do
+      <<~HTML
+        <div></div>
+        <p></p>
+        #{html_clean}
+      HTML
+    end
+    let(:nodes) do
+      Nokogiri::HTML.fragment html
+    end
+
+    subject { described_class.strip_content(nodes) }
+
+    it 'remove empty ELEMENTS before first one with content' do
+      subject
+      expect(nodes.to_s.squish).to eq html_clean.squish
     end
   end
 end


### PR DESCRIPTION
Lcms::Engine::HtmlSanitizer.strip_content now correctly strips the empty elements. Before the fix general text elements were ignored by default.

Now stripping content like
```html
<p></p>
{{inset_11e85cccf407299a81ef}}
<p></p>
<h3 style="text-align:left;">
  <span style="font-style:italic">In place of a semicolon</span><span>: The use of an em dash here is to create overwhelming emphasis or pause to influence shock and awe in your readers. </span>
</h3>
<p></p>
{{inset_392e9effbf47d0988b8c}}
<p></p>
```
will produce
```html
{{inset_11e85cccf407299a81ef}}
<p></p>
<h3 style="text-align:left;">
  <span style="font-style:italic">In place of a semicolon</span><span>: The use of an em dash here is to create overwhelming emphasis or pause to influence shock and awe in your readers. </span>
</h3>
<p></p>
{{inset_392e9effbf47d0988b8c}}
<p></p>
```

Before the fix resulting HTML would be
```html
<h3 style="text-align:left;">
  <span style="font-style:italic">In place of a semicolon</span><span>: The use of an em dash here is to create overwhelming emphasis or pause to influence shock and awe in your readers. </span>
</h3>
<p></p>
{{inset_392e9effbf47d0988b8c}}
<p></p>
```
TEXT element at the top is lost.