### PR TITLE
Capture errors during metadata parsing

### DIFF
--- a/app/controllers/lcms/engine/admin/documents_controller.rb
+++ b/app/controllers/lcms/engine/admin/documents_controller.rb
@@ -30,7 +30,7 @@ module Lcms
           @document = reimport_lesson
           if @document.save
             redirect_to AdminController.document_path(@document.document),
-                        notice: t('.success', name: @document.document.name)
+                        notice: t('.success', name: @document.document.name, errors: collect_errors)
           else
             render :new
           end
@@ -72,6 +72,12 @@ module Lcms
             jobs_[job_id] = { link: link, status: 'waiting' }
           end
           @props = { jobs: jobs, type: :documents, links: view_links }
+        end
+
+        def collect_errors
+          return if @document.service_errors.empty?
+
+          "Errors: #{@document.service_errors.join(' ')}"
         end
 
         def find_selected

--- a/app/forms/lcms/engine/material_form.rb
+++ b/app/forms/lcms/engine/material_form.rb
@@ -11,7 +11,7 @@ module Lcms
       attribute :source_type, String
       validates :link, presence: true
 
-      attr_accessor :material
+      attr_accessor :material, :service_errors
 
       def initialize(attributes = {}, opts = {})
         super(attributes)
@@ -28,6 +28,7 @@ module Lcms
         }.compact
         service = MaterialBuildService.new google_credentials, params
         @material = service.build link
+        @service_errors = service.errors
 
         material.update preview_links: {}
         after_reimport_hook

--- a/app/javascript/components/admin/ImportStatus.jsx
+++ b/app/javascript/components/admin/ImportStatus.jsx
@@ -100,6 +100,7 @@ class ImportStatus extends React.Component {
             {job.status === 'done' && job.ok ? <span>{this.resourceButton(job)}</span> : null}
           </div>
           {job.errors ? (<p dangerouslySetInnerHTML={{__html: _.join(job.errors, '<br/>')}}></p>) : null}
+          {job.warnings ? (<p dangerouslySetInnerHTML={{ __html: _.join(job.warnings, '<br/>') }}></p>) : null}
         </li>
       )
     })

--- a/app/jobs/lcms/engine/document_parse_job.rb
+++ b/app/jobs/lcms/engine/document_parse_job.rb
@@ -31,7 +31,7 @@ module Lcms
       def reimport_document(link)
         form = DocumentForm.new({ link: link }, import_retry: true)
         @result = if form.save
-                    { ok: true, link: link, model: form.document }
+                    { ok: true, link: link, model: form.document, warnings: form.service_errors }
                   else
                     { ok: false, link: link, errors: form.errors[:link] }
                   end

--- a/app/services/lcms/engine/document_build_service.rb
+++ b/app/services/lcms/engine/document_build_service.rb
@@ -7,8 +7,11 @@ module Lcms
     class DocumentBuildService
       EVENT_BUILT = 'document:built'
 
+      attr_reader :errors
+
       def initialize(credentials, opts = {})
         @credentials = credentials
+        @errors = []
         @options = opts
       end
 
@@ -19,6 +22,7 @@ module Lcms
         @content = download url
         @expand_document = expand
         @template = DocTemplate::Template.parse @content
+        @errors = @template.metadata_service.errors
 
         create_document
         clear_preview_link

--- a/app/services/lcms/engine/material_build_service.rb
+++ b/app/services/lcms/engine/material_build_service.rb
@@ -9,8 +9,11 @@ module Lcms
       EVENT_BUILT = 'material:built'
       PDF_EXT_RE = /\.pdf$/
 
+      attr_reader :errors
+
       def initialize(credentials, opts = {})
         @credentials = credentials
+        @errors = []
         @options = opts
       end
 
@@ -60,6 +63,7 @@ module Lcms
         create_material
         content = @downloader.download.content
         template = DocTemplate::Template.parse(content, type: :material)
+        @errors = template.metadata_service.errors
 
         metadata = template.metadata_service.options_for(:default)[:metadata]
         material.update!(

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -216,7 +216,7 @@ en:
           create:
             empty_folder: Google Documents folder is empty
             error: Error
-            success: Lesson %{name} parsed successfully.
+            success: Lesson %{name} parsed successfully. %{errors}
           new:
             page_title: Add a lesson
             submit: Parse

--- a/lib/doc_template/tables/base.rb
+++ b/lib/doc_template/tables/base.rb
@@ -5,7 +5,7 @@ module DocTemplate
     class Base
       SPLIT_REGEX = /[,;\r\n]/
 
-      attr_reader :data
+      attr_reader :errors, :data
 
       def self.parse(fragment, *args)
         new.parse(fragment, *args)
@@ -13,6 +13,7 @@ module DocTemplate
 
       def initialize
         @data = {}
+        @errors = []
         @table_exists = false
       end
 

--- a/lib/lt/lcms/metadata/base_service.rb
+++ b/lib/lt/lcms/metadata/base_service.rb
@@ -6,7 +6,7 @@ module Lt
     module Metadata
       class BaseService
         class << self
-          attr_reader :activity_metadata, :metadata, :section_metadata
+          attr_reader :activity_metadata, :errors, :metadata, :section_metadata
 
           def materials_metadata
             raise NotImplementedError
@@ -22,6 +22,7 @@ module Lt
           end
 
           def parse(_content, *args)
+            @errors = []
             @options = args.extract_options!
           end
 

--- a/lib/lt/lcms/metadata/service.rb
+++ b/lib/lt/lcms/metadata/service.rb
@@ -39,9 +39,11 @@ module Lt
             super
             if material?
               @metadata = DocTemplate::Tables::MaterialMetadata.parse content
+              @errors.concat @metadata.errors
               raise ::MaterialError, 'No metadata present' if !@metadata&.table_exist? || @metadata&.data&.empty?
             else
               @metadata = DocTemplate::Tables::Metadata.parse content
+              @errors.concat @metadata.errors
               raise ::DocumentError, 'No metadata present' unless @metadata&.table_exist?
 
               @agenda = DocTemplate::Tables::Agenda.parse content

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -9,7 +9,9 @@ describe Lcms::Engine::Admin::DocumentsController do
 
   describe '#create' do
     let(:document) { create :document }
-    let(:form) { instance_double('Lcms::Engine::DocumentForm', document: document, save: valid) }
+    let(:form) do
+      instance_double('Lcms::Engine::DocumentForm', document: document, save: valid, service_errors: [])
+    end
     let(:link) { 'link' }
     let(:params) { { link: link, link_fs: 'link_fs', reimport: '1' } }
     let(:valid) { true }

--- a/spec/forms/document_form_spec.rb
+++ b/spec/forms/document_form_spec.rb
@@ -10,7 +10,7 @@ describe Lcms::Engine::DocumentForm do
 
   describe '#save' do
     let(:document) { create :document }
-    let(:service) { instance_double('DocumentBuildService', build_for: document) }
+    let(:service) { instance_double('DocumentBuildService', build_for: document, errors: []) }
 
     subject { form.save }
 
@@ -62,6 +62,16 @@ describe Lcms::Engine::DocumentForm do
           expect(service).to receive(:build_for).with(params[:link])
           expect(service).to receive(:build_for).with(params[:link_fs], expand: true)
           subject
+        end
+      end
+
+      context 'when there are non-critical errors' do
+        let(:errors) { %w(error-1 error-2 error-3) }
+        let(:service) { instance_double('DocumentBuildService', build_for: document, errors: errors) }
+
+        it 'store service errors' do
+          subject
+          expect(form.service_errors).to eq errors
         end
       end
     end


### PR DESCRIPTION
Non-critical errors occurred during document or material metadata parsing now can be fetched during import process. In case when import process is running using ActiveJob workers, non-critical warnings can be fetched from Redis with general job results.