### PR TITLE
Update usage of external decorators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/app/views/lcms/engine/admin/materials/index.html.erb
+++ b/app/views/lcms/engine/admin/materials/index.html.erb
@@ -71,7 +71,7 @@
                   <% lesson = ::Lcms::Engine::DocumentGenerator.document_presenter.new lesson %>
                   <li class="u-text--small">
                     <a href="<%= lesson.file_url%>" target="_blank" class="materials-table__lessons--file"><i class="fab fa-google"></i></a>
-                    <%= link_to lesson.title, dynamic_path(lesson, request.query_parameters), target: '_blank' %>
+                    <%= link_to lesson.title, dynamic_path(:material_path, lesson, request.query_parameters), target: '_blank' %>
                   </li>
                 <% end %>
               </ul>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
 
   app:
     build: .
-    command: bash -c "bundle install && yarn && tail -f /dev/null"
+    # Used to install native gem which solves build errors for nokogumbo and other gems
+    command: bash -c "gem install nokogiri && bundle install && yarn && tail -f /dev/null"
     env_file:
       - spec/dummy/.env.docker
     environment:

--- a/lib/lcms/engine/engine.rb
+++ b/lib/lcms/engine/engine.rb
@@ -66,8 +66,14 @@ module Lcms
         # Check if the DB exists
         next unless ActiveRecord::Base.connection
 
+        # Possible decorators
+        decorators = %W[
+          #{Rails.root}/app/decorators/**/*_decorator*.rb
+          #{Rails.root}/app/**/lcms/engine/*_decorator*.rb
+        ]
+
         Dir
-          .glob("#{Rails.root}/app/decorators/**/*_decorator*.rb")
+          .glob(decorators)
           .sort
           .each(&method(:require))
       rescue ActiveRecord::NoDatabaseError


### PR DESCRIPTION
Update usage of external decorators

- Also updates mimemagic gem

- Since Rails 6 introduced zeitwerk autoloader we need to review and change the way host application decorates engine's objects.

Consider the host application is named `MyApp`, then to decorate lcms-engine's objects the following should be done.

```ruby
# my_app/app/models/my_app/lcms/engine/user_decorator.rb
module MyApp
  module Lcms
    module Engine
      module UserDecorator
        def self.prepended(base)
          # Any scope or possible class methods
          base.before_validation :some_method
        end

        def some_other_method
          true
        end
      end
    end
  end
end

::Lcms::Engine::User.prepend(MyApp::Lcms::Engine::UserDecorator)
```