### PR TITLE
(#117) Import single document/material via delayed job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/learningtapestry/lcms-engine/compare/v0.1.4...HEAD)
 
+### Added
+
+- Materials and Documents can now be imported asynchronous [@paranoicsan](https://github.com/paranoicsan)
+
 ### Changed
 
 - Bump lt-google-api to 0.2.3

--- a/app/views/lcms/engine/admin/documents/new.html.erb
+++ b/app/views/lcms/engine/admin/documents/new.html.erb
@@ -2,7 +2,11 @@
   <h2 class=text-center><%= t('.page_title') %></h2>
 
   <%= simple_form_for @document || DocumentForm.new, url: [:admin, :documents] do |f| %>
-      <%= f.input :link, error: f.object.errors[:link].first.try(:html_safe), label: t('ui.url') %>
+    <%= f.input :link, error: f.object.errors[:link].first.try(:html_safe), label: t('ui.url') %>
+    <p>
+      <%= f.check_box :async, checked: true %>
+      <span><small><%= t('ui.async') %></small></span>
+    </p>
     <%= f.button :submit, t('.submit') %>
   <% end %>
 </div>

--- a/app/views/lcms/engine/admin/materials/new.html.erb
+++ b/app/views/lcms/engine/admin/materials/new.html.erb
@@ -4,6 +4,10 @@
   <%= simple_form_for @material_form, url: [:admin, :materials] do |f| %>
     <%= f.hidden_field :source_type, value: @material_form.source_type %>
     <%= f.input :link, label: t('ui.url') %>
+    <p>
+      <%= f.check_box :async, checked: true %>
+      <span><small><%= t('ui.async') %></small></span>
+    </p>
     <%= f.button :submit, t('.submit') %>
   <% end %>
 </div>

--- a/config/locales/ui/en.yml
+++ b/config/locales/ui/en.yml
@@ -124,6 +124,7 @@ en:
     add: Add
     all: All
     are_you_sure: Are you sure?
+    async: Asynchronously
     close: Close
     contents: Contents
     delete: Delete

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -69,6 +69,18 @@ describe Lcms::Engine::Admin::DocumentsController do
         end
       end
     end
+
+    context 'when asynchronous import was requested' do
+      let(:link) { 'https://google.com/somefile' }
+      let(:params) { { async: '1', link: link } }
+
+      before { allow(controller).to receive(:bulk_import) }
+
+      it 'calls bulk import for that particular document' do
+        expect(controller).to receive(:bulk_import).with(Array.wrap(link))
+        subject
+      end
+    end
   end
 
   describe '#destroy' do

--- a/spec/controllers/admin/materials_controller_spec.rb
+++ b/spec/controllers/admin/materials_controller_spec.rb
@@ -67,6 +67,17 @@ describe Lcms::Engine::Admin::MaterialsController do
         end
       end
     end
+
+    context 'when asynchronous import was requested' do
+      let(:params) { { async: '1', link: link } }
+
+      before { allow(controller).to receive(:bulk_import) }
+
+      it 'calls bulk import for that particular document' do
+        expect(controller).to receive(:bulk_import).with(Array.wrap(link))
+        subject
+      end
+    end
   end
 
   describe '#destroy' do

--- a/spec/features/admin/materials/add_material_spec.rb
+++ b/spec/features/admin/materials/add_material_spec.rb
@@ -44,6 +44,7 @@ feature 'Admin adds a material' do
     expect(page).to have_field :material_form_link
 
     fill_in :material_form_link, with: data[:url]
+    find('#material_form_async').uncheck
     click_button 'Parse'
 
     expect(Lcms::Engine::Material.last.name).to eql(data[:file_name])
@@ -66,6 +67,7 @@ feature 'Admin adds a material' do
     allow(Lcms::Engine::S3Service).to receive(:upload)
 
     fill_in :material_form_link, with: data[:url]
+    find('#material_form_async').uncheck
     click_button 'Parse'
 
     expect(Lcms::Engine::Material.last.name).to eql(data[:file_name])


### PR DESCRIPTION
Refs #117

Add special checkbox (checked by default) to import document/material using ActiveJob.

The same functionality for Rails 6 has been added with #184 