### PR TITLE
(#196) Error 404 when deleting materials/lessons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,8 +219,9 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.35.3)
+    capybara (3.36.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
@@ -432,6 +433,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     memoist (0.16.2)
     method_source (1.0.0)
     migration_data (0.6.0)

--- a/app/controllers/lcms/engine/admin/documents_controller.rb
+++ b/app/controllers/lcms/engine/admin/documents_controller.rb
@@ -28,12 +28,12 @@ module Lcms
         def destroy
           @document = Document.find(params[:id])
           @document.destroy
-          redirect_to admin_documents_path(query: @query_params), notice: t('.success')
+          redirect_to lcms_engine.admin_documents_path(query: @query_params), notice: t('.success')
         end
 
         def destroy_selected
           count = @documents.destroy_all.count
-          redirect_to admin_documents_path(query: @query_params), notice: t('.success', count: count)
+          redirect_to lcms_engine.admin_documents_path(query: @query_params), notice: t('.success', count: count)
         end
 
         def import_status

--- a/app/controllers/lcms/engine/admin/materials_controller.rb
+++ b/app/controllers/lcms/engine/admin/materials_controller.rb
@@ -28,12 +28,12 @@ module Lcms
         def destroy
           material = Material.find(params[:id])
           material.destroy
-          redirect_to admin_materials_path(query: @query_params), notice: t('.success')
+          redirect_to lcms_engine.admin_materials_path(query: @query_params), notice: t('.success')
         end
 
         def destroy_selected
           count = @materials.destroy_all.count
-          redirect_to admin_materials_path(query: @query_params), notice: t('.success', count: count)
+          redirect_to lcms_engine.admin_materials_path(query: @query_params), notice: t('.success', count: count)
         end
 
         def import_status

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -93,6 +93,14 @@ describe Lcms::Engine::Admin::DocumentsController do
     it 'deletes the document' do
       expect { subject }.to change(Lcms::Engine::Document, :count).by(-1)
     end
+
+    context 'when there was custom filter' do
+      let(:query) { { course: 'value' } }
+
+      subject { delete :destroy, params: { id: document.id, query: query } }
+
+      it { is_expected.to redirect_to "/lcms-engine/admin/documents?#{{ query: query }.to_param}" }
+    end
   end
 
   describe '#new' do

--- a/spec/controllers/admin/materials_controller_spec.rb
+++ b/spec/controllers/admin/materials_controller_spec.rb
@@ -96,7 +96,7 @@ describe Lcms::Engine::Admin::MaterialsController do
 
       subject { delete :destroy, params: { id: material.id, query: query } }
 
-      it { is_expected.to redirect_to admin_materials_path(query: query) }
+      it { is_expected.to redirect_to "/lcms-engine/admin/materials?#{{ query: query }.to_param}" }
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,21 +38,4 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
-
-  config.before(:suite) do
-    # Rails 4.2 call `initialize` inside `recycle!`. However Ruby 2.6 doesn't allow calling `initialize` twice.
-    # See for detail: https://github.com/rails/rails/issues/34790
-    if RUBY_VERSION.to_f >= 2.6 && Rails::VERSION::MAJOR == 4
-      class ActionController::TestResponse # rubocop:disable Style/ClassAndModuleChildren
-        prepend Module.new {
-          def recycle!
-            # Patch to avoid MonitorMixin double-initialize error:
-            @mon_mutex_owner_object_id = nil
-            @mon_mutex = nil
-            super
-          end
-        }
-      end
-    end
-  end
 end


### PR DESCRIPTION
Fixes #196

Error occurs when the engine is mounted to a non-general path. We should explicitly set  `lcms_engine.` path helper prefix instead of raw engine path to redirect correctly.

Now redirection leads us to the path as
```
/assets?action=index&controller=lcms%2Fengine%2Fadmin%2Fdocuments
```