### PR TITLE
Allow S3Service to upload with options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicitly skip indexing via ElasticSearch for objects which include Lcms::Engine::Searchable concern
 - Replace sass-lint to stylelint NodeJS package
 - Bump webpacker gem (and @rails/webpacker package)
+- `Lcms::Engine::S3Service.upload` method now accepts options Hash to be passed to AWS S3 resource
 
 ### Changed
 

--- a/app/services/lcms/engine/s3_service.rb
+++ b/app/services/lcms/engine/s3_service.rb
@@ -12,9 +12,21 @@ module Lcms
           .object(key)
       end
 
-      def self.upload(key, data)
+      #
+      # Upload data to the specified resource by key
+      #
+      # @param [String] key Key of the object. Usually represents the full path inside a bucket
+      # @param [IO|StringIO] data The data to be uploaded
+      # @param [Hash] options Additional options to be passed to Aws::S3::Object#put method
+      #
+      # @return [String] The final URL of the uploaded object
+      #
+      def self.upload(key, data, options = {})
         object = create_object key
-        object.put(body: data)
+        options = options.merge(
+          body: data
+        )
+        object.put(options)
         object.public_url
       end
 

--- a/spec/services/s3_service_spec.rb
+++ b/spec/services/s3_service_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lcms::Engine::S3Service do
+  describe '.upload' do
+    let(:data) { StringIO.new('data to be uploaded') }
+    let(:full_options) { options.merge(body: data) }
+    let(:key) { 'path/to/file' }
+    let(:object) do
+      params = {
+        put: 'true',
+        public_url: url
+      }
+      double(::Aws::S3::Resource, **params)
+    end
+    let(:options) { { content_type: 'image/png' } }
+    let(:url) { Faker::Internet.url }
+
+    before { allow(described_class).to receive(:create_object).with(key).and_return(object) }
+
+    subject { described_class.upload(key, data, options) }
+
+    it 'uploads data with passed params' do
+      expect(object).to receive(:put).with(full_options)
+      subject
+    end
+
+    it 'returns URL of the uploaded object'
+  end
+end


### PR DESCRIPTION
Now one can pass a hash with options for the target S3 object. The list of options can be found in the description of `Aws::S3::Object#put` method.