### PR TITLE
Fix "undefined method `dynamic_path'"

### DIFF
--- a/app/controllers/lcms/engine/admin/admin_controller.rb
+++ b/app/controllers/lcms/engine/admin/admin_controller.rb
@@ -4,6 +4,8 @@ module Lcms
   module Engine
     module Admin
       class AdminController < Lcms::Engine::ApplicationController
+        include Lcms::Engine::PathHelper
+
         CONFIG_PATH ||= Rails.root.join('config', 'lcms-admin.yml')
 
         DEFAULTS ||= {


### PR DESCRIPTION
Occurred when non-admin user tried to access the Admin panel. Redirection didn't work as expected.