### PR TITLE
Fix Admin panel routes

### DIFF
--- a/app/controllers/lcms/engine/admin/access_codes_controller.rb
+++ b/app/controllers/lcms/engine/admin/access_codes_controller.rb
@@ -9,7 +9,7 @@ module Lcms
         def create
           @access_code = AccessCode.new(permitted_params)
           if @access_code.save
-            redirect_to({ action: :index }, notice: t('.success'))
+            redirect_to lcms_engine.admin_access_codes_path, notice: t('.success')
           else
             render :new
           end
@@ -17,7 +17,11 @@ module Lcms
 
         def destroy
           @access_code.destroy
-          redirect_to({ action: :index }, notice: t('.success'))
+          redirect_to lcms_engine.admin_access_codes_path, notice: t('.success')
+        end
+
+        def edit
+          @url = lcms_engine.admin_access_code_path(@access_code)
         end
 
         def index
@@ -30,8 +34,9 @@ module Lcms
 
         def update
           if @access_code.update(permitted_params)
-            redirect_to({ action: :index }, notice: t('.success'))
+            redirect_to lcms_engine.admin_access_codes_path, notice: t('.success')
           else
+            @url = lcms_engine.admin_access_code_path(@access_code)
             render :edit
           end
         end

--- a/app/controllers/lcms/engine/admin/curriculums_controller.rb
+++ b/app/controllers/lcms/engine/admin/curriculums_controller.rb
@@ -11,7 +11,7 @@ module Lcms
         def update
           @form = CurriculumForm.new(params[:curriculum])
           if @form.save
-            redirect_to admin_path, notice: t('.success')
+            redirect_to lcms_engine.root_path, notice: t('.success')
           else
             @curriculum = CurriculumPresenter.new
             render :edit, alert: t('.error')

--- a/app/controllers/lcms/engine/admin/resource_bulk_edits_controller.rb
+++ b/app/controllers/lcms/engine/admin/resource_bulk_edits_controller.rb
@@ -10,7 +10,7 @@ module Lcms
           if @resources.any?
             @resource = BulkEditResourcesService.new(@resources).init_sample
           else
-            redirect_to :admin_resources, alert: t('.no_resources')
+            redirect_to lcms_engine.admin_resources_path, alert: t('.no_resources')
           end
         end
 
@@ -18,7 +18,7 @@ module Lcms
           BulkEditResourcesService.new(@resources, resource_params).edit!
           resources_count_msg = t(:resources_count, count: @resources.count)
           notice = t('.success', count: @resources.count, resources_count: resources_count_msg)
-          redirect_to :admin_resources, notice: notice
+          redirect_to lcms_engine.admin_resources_path, notice: notice
         end
 
         private

--- a/app/controllers/lcms/engine/admin/resources_controller.rb
+++ b/app/controllers/lcms/engine/admin/resources_controller.rb
@@ -30,7 +30,7 @@ module Lcms
 
           if @resource.save
             create_tags
-            redirect_to :admin_resources, notice: t('.success', resource_id: @resource.id)
+            redirect_to lcms_engine.admin_resources_path, notice: t('.success', resource_id: @resource.id)
           else
             render :new
           end
@@ -50,17 +50,17 @@ module Lcms
         end
 
         def bundle
-          return redirect_to :admin_resources, notice: t('.fail') unless can_bundle?(@resource)
+          return redirect_to lcms_engine.admin_resources_path, notice: t('.fail') unless can_bundle?(@resource)
 
           # see settings loaded via `lcms.yml`
           generator = DocTemplate.config.dig('bundles', @resource.curriculum_type).constantize
           generator.perform(@resource)
-          redirect_to :admin_resources, notice: t('.success')
+          redirect_to lcms_engine.admin_resources_path, notice: t('.success')
         end
 
         def update
           unless Settings[:editing_enabled]
-            return redirect_to(:admin_resources, alert: t('admin.common.editing_disabled'))
+            return redirect_to(lcms_engine.admin_resources_path, alert: t('admin.common.editing_disabled'))
           end
 
           create_tags
@@ -70,7 +70,7 @@ module Lcms
           end
 
           if @resource.update(resource_params)
-            redirect_to :admin_resources, notice: t('.success', resource_id: @resource.id)
+            redirect_to lcms_engine.admin_resources_path, notice: t('.success', resource_id: @resource.id)
           else
             render :edit
           end
@@ -78,7 +78,7 @@ module Lcms
 
         def destroy
           @resource.destroy
-          redirect_to :admin_resources, notice: t('.success', resource_id: @resource.id)
+          redirect_to lcms_engine.admin_resources_path, notice: t('.success', resource_id: @resource.id)
         end
 
         protected

--- a/app/controllers/lcms/engine/admin/settings_controller.rb
+++ b/app/controllers/lcms/engine/admin/settings_controller.rb
@@ -7,7 +7,7 @@ module Lcms
         def toggle_editing_enabled
           Settings[:editing_enabled] = !Settings[:editing_enabled]
           notice = Settings[:editing_enabled] ? t('.enabled') : t('.disabled')
-          redirect_to :admin_resources, notice: notice
+          redirect_to lcms_engine.admin_resources_path, notice: notice
         end
       end
     end

--- a/app/controllers/lcms/engine/admin/standards_controller.rb
+++ b/app/controllers/lcms/engine/admin/standards_controller.rb
@@ -20,7 +20,7 @@ module Lcms
 
         def update
           if @standard.update(standard_params)
-            redirect_to admin_standards_path, notice: t('.success')
+            redirect_to lcms_engine.admin_standards_path, notice: t('.success')
           else
             render :edit
           end

--- a/app/controllers/lcms/engine/admin/users_controller.rb
+++ b/app/controllers/lcms/engine/admin/users_controller.rb
@@ -21,30 +21,33 @@ module Lcms
           @user.generate_password
           if @user.save
             @user.send_reset_password_instructions
-            redirect_to(:admin_users, notice: t('.success', user: @user.email))
+            redirect_to lcms_engine.admin_users_path, notice: t('.success', user: @user.email)
           else
             render :new
           end
         end
 
-        def edit; end
+        def edit
+          @url = lcms_engine.admin_user_path(@user)
+        end
 
         def update
           if @user.update(user_params)
-            redirect_to edit_admin_user_path(@user), notice: t('.success', user: @user.email)
+            redirect_to lcms_engine.admin_users_path, notice: t('.success', user: @user.email)
           else
+            @url = lcms_engine.admin_user_path(@user)
             render :edit
           end
         end
 
         def destroy
           @user.destroy
-          redirect_to :admin_users, notice: t('.success')
+          redirect_to lcms_engine.admin_users_path, notice: t('.success')
         end
 
         def reset_password
           @user.send_reset_password_instructions
-          redirect_to :admin_users, notice: t('.success')
+          redirect_to lcms_engine.admin_users_path, notice: t('.success')
         end
 
         private

--- a/app/controllers/lcms/engine/resources_controller.rb
+++ b/app/controllers/lcms/engine/resources_controller.rb
@@ -7,13 +7,13 @@ module Lcms
         @resource = find_resource
 
         # redirect to document if resource has it (#161)
-        return redirect_to document_path(@resource.document) if @resource.document?
+        return redirect_to dynamic_document_path(@resource.document) if @resource.document?
 
         # redirect grade and module to explore_curriculum (#122)
-        return redirect_to explore_curriculum_index_path(p: @resource.slug, e: 1) if grade_or_module?
+        return redirect_to lcms_engine.explore_curriculum_index_path(p: @resource.slug, e: 1) if grade_or_module?
 
         # redirect to the path with slug if we are using just the id
-        return redirect_to show_with_slug_path(@resource.slug), status: 301 if using_id?
+        return redirect_to lcms_engine.show_with_slug_path(@resource.slug), status: 301 if using_id?
 
         @related_instructions = related_instructions
         @props = CurriculumMap.new(@resource).props
@@ -27,14 +27,14 @@ module Lcms
 
       def media
         resource = Resource.find(params[:id])
-        return redirect_to resource_path(resource) unless resource.media?
+        return redirect_to lcms_engine.resource_path(resource) unless resource.media?
 
         @resource = MediaPresenter.new(resource)
       end
 
       def generic
         resource = Resource.find(params[:id])
-        return redirect_to resource_path(resource) unless resource.generic?
+        return redirect_to lcms_engine.resource_path(resource) unless resource.generic?
 
         @resource = GenericPresenter.new(resource)
       end

--- a/app/views/lcms/engine/admin/access_codes/_form.html.erb
+++ b/app/views/lcms/engine/admin/access_codes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [:admin, @access_code], html: { id: 'access_code_form' } do |f| %>
+<%= simple_form_for @access_code, url: @url.presence || lcms_engine.admin_access_codes_path, html: { id: 'access_code_form' } do |f| %>
   <%= f.input :code %>
   <%= f.input :active %>
   <%= f.button :submit, t('ui.save'), name: nil %>

--- a/app/views/lcms/engine/admin/access_codes/index.html.erb
+++ b/app/views/lcms/engine/admin/access_codes/index.html.erb
@@ -1,7 +1,7 @@
 <div class=o-page>
   <div class=clearfix>
     <div class=pull-right>
-      <%= link_to t('.new_access_code'), :new_admin_access_code, class: 'button success', 'data-turbolinks' => false %>
+      <%= link_to t('.new_access_code'), lcms_engine.new_admin_access_code_path, class: 'button success', 'data-turbolinks' => false %>
     </div>
   </div>
 
@@ -19,10 +19,10 @@
         <% @access_codes.each do |access_code| %>
           <% cache access_code do %>
             <tr id="access_code_<%= access_code.id %>">
-              <td><%= link_to access_code.code, edit_admin_access_code_path(access_code) %>
+              <td><%= link_to access_code.code, lcms_engine.edit_admin_access_code_path(access_code) %>
               <td><%= access_code.active ? 'YES' : 'NO' %>
               <td>
-                <%= button_to t('ui.delete'), admin_access_code_path(access_code), class: 'button alert', data: { confirm: t('ui.are_you_sure') }, form_class: 'inline', method: :delete %>
+                <%= button_to t('ui.delete'), lcms_engine.admin_access_code_path(access_code), class: 'button alert', data: { confirm: t('ui.are_you_sure') }, form_class: 'inline', method: :delete %>
               </td>
             </tr>
           <% end %>

--- a/app/views/lcms/engine/admin/batch_reimports/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/batch_reimports/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for :query, url: :admin_batch_reimport, html: { class: 'form-inline well o-admin-lessons-search', method: :post } do |f| %>
+<%= simple_form_for :query, url: lcms_engine.admin_batch_reimport_path, html: { class: 'form-inline well o-admin-lessons-search', method: :post } do |f| %>
 
   <div class="row align-bottom align-justify">
     <button class="button o-admin-search-subject float-right" type="button" data-toggle="subject">Select Subject</button>

--- a/app/views/lcms/engine/admin/documents/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/documents/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for :query, url: :admin_documents, html: { class: 'form-inline well o-admin-lessons-search', method: :get } do |f| %>
+<%= simple_form_for :query, url: lcms_engine.admin_documents_path, html: { class: 'form-inline well o-admin-lessons-search', method: :get } do |f| %>
 
   <div class='row align-bottom align-justify'>
     <button class="button o-admin-search-subject float-right" type="button" data-toggle="lesson-subject">Select Subject</button>

--- a/app/views/lcms/engine/admin/documents/index.html.erb
+++ b/app/views/lcms/engine/admin/documents/index.html.erb
@@ -24,7 +24,7 @@
             path: delete_selected_admin_documents_path(query: @query_params),
             btn_style: 'alert'} %>
 
-      <%= link_to t('.new_lesson'), :new_admin_document, class: 'button primary' %>
+      <%= link_to t('.new_lesson'), lcms_engine.new_admin_document_path, class: 'button primary' %>
     </div>
     <table class="lessons-table table">
       <tr>

--- a/app/views/lcms/engine/admin/materials/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/materials/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for :query, url: :admin_materials, html: { class: 'form-inline well o-admin-lessons-search', method: :get } do |f| %>
+<%= simple_form_for :query, url: lcms_engine.admin_materials_path, html: { class: 'form-inline well o-admin-lessons-search', method: :get } do |f| %>
 
   <div class="row align-bottom align-justify">
     <%= f.input :search_term, label: 'Identifier', required: false,

--- a/app/views/lcms/engine/admin/materials/index.html.erb
+++ b/app/views/lcms/engine/admin/materials/index.html.erb
@@ -24,7 +24,7 @@
             path: delete_selected_admin_materials_path(query: @query_params),
             btn_style: 'alert'} %>
       <%# link_to t('.new_material_pdf'), new_admin_material_path(source_type: 'pdf'), class: 'button primary' %>
-      <%= link_to t('.new_material'), :new_admin_material, class: 'button primary' %>
+      <%= link_to t('.new_material'), lcms_engine.new_admin_material_path, class: 'button primary' %>
     </div>
     <div class="materials-table materials-table__wrapper">
       <table class="table u-text--centered">

--- a/app/views/lcms/engine/admin/resource_bulk_edits/new.html.erb
+++ b/app/views/lcms/engine/admin/resource_bulk_edits/new.html.erb
@@ -1,7 +1,7 @@
 <div class=o-page>
   <h2 class=text-center><%= t('.page_title') %></h2>
 
-  <%= simple_form_for @resource, url: :admin_resource_bulk_edits do |f| %>
+  <%= simple_form_for @resource, url: lcms_engine.admin_resource_bulk_edits_path do |f| %>
 
     <% @resources.each do |resource| %>
       <%= hidden_field_tag 'ids[]', resource.id %>

--- a/app/views/lcms/engine/admin/resources/_form.html.erb
+++ b/app/views/lcms/engine/admin/resources/_form.html.erb
@@ -1,4 +1,4 @@
-<% url = @resource.new_record? ? :admin_resources : admin_resource_path(@resource) %>
+<% url = @resource.new_record? ? lcms_engine.admin_resources_path : lcms_engine.admin_resource_path(@resource) %>
 
 <%= simple_nested_form_for @resource, url: url, html: { id: 'resource_form' } do |f| %>
   <div class="large-10 columns">

--- a/app/views/lcms/engine/admin/resources/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/resources/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @query, url: :admin_resources, html: { class: 'form-inline well admin-resource-search', method: :get } do |f| %>
+<%= simple_form_for @query, url: lcms_engine.admin_resources_path, html: { class: 'form-inline well admin-resource-search', method: :get } do |f| %>
 
   <div class='row align-justify'>
     <%= f.input :grades, as: :select, collection: Lcms::Engine::Grades.grades, input_html: { class: 'selectize resource-search-select', multiple: true }, label: t('.grades'), label_method: :humanize, required: false, wrapper_html: { class: 'resource-search-wrap' } %>

--- a/app/views/lcms/engine/admin/shared/_header.html.erb
+++ b/app/views/lcms/engine/admin/shared/_header.html.erb
@@ -13,36 +13,36 @@
         <div class="o-top-bar__item c-header__menu">
           <ul class="dropdown menu" data-dropdown-menu>
             <li class="c-header__link">
-              <%= link_to t('lcms.engine.admin.nav.curriculum'), edit_admin_curriculum_path %>
+              <%= link_to t('lcms.engine.admin.nav.curriculum'), lcms_engine.edit_admin_curriculum_path %>
             </li>
 
             <li class="dropdown c-header__link">
-              <%= link_to t('lcms.engine.admin.nav.resources'), admin_resources_path %>
+              <%= link_to t('lcms.engine.admin.nav.resources'), lcms_engine.admin_resources_path %>
               <ul class="menu vertical">
-                <%= nav_link t('lcms.engine.admin.nav.resources'), admin_resources_path %>
-                <%= nav_link t('lcms.engine.admin.nav.add_resource'), new_admin_resource_path %>
+                <%= nav_link t('lcms.engine.admin.nav.resources'), lcms_engine.admin_resources_path %>
+                <%= nav_link t('lcms.engine.admin.nav.add_resource'), lcms_engine.new_admin_resource_path %>
                 <%#= nav_link t('lcms.engine.admin.nav.sketch_compilation', version: 'v1'), new_admin_sketch_compiler_path(:v1) %>
                 <%#= nav_link t('lcms.engine.admin.nav.sketch_compilation', version: 'v2'), new_admin_sketch_compiler_path(:v2) %>
-                <%= nav_link t('lcms.engine.admin.nav.lessons'), admin_documents_path %>
-                <%= nav_link t('lcms.engine.admin.nav.materials'), admin_materials_path %>
-                <%= nav_link t('lcms.engine.admin.nav.batch_reimport'), new_admin_batch_reimport_path %>
+                <%= nav_link t('lcms.engine.admin.nav.lessons'), lcms_engine.admin_documents_path %>
+                <%= nav_link t('lcms.engine.admin.nav.materials'), lcms_engine.admin_materials_path %>
+                <%= nav_link t('lcms.engine.admin.nav.batch_reimport'), lcms_engine.new_admin_batch_reimport_path %>
               </ul>
             </li>
 
             <li class="c-header__link">
-              <%= link_to t('lcms.engine.admin.nav.standards'), admin_standards_path %>
+              <%= link_to t('lcms.engine.admin.nav.standards'), lcms_engine.admin_standards_path %>
             </li>
 
             <li class="dropdown c-header__link">
-              <%= link_to t('lcms.engine.admin.nav.users'), admin_users_path %>
+              <%= link_to t('lcms.engine.admin.nav.users'), lcms_engine.admin_users_path %>
               <ul class="menu vertical">
-                <%= nav_link t('lcms.engine.admin.nav.users'), admin_users_path %>
-                <%= nav_link t('lcms.engine.admin.nav.access_codes'), admin_access_codes_path %>
+                <%= nav_link t('lcms.engine.admin.nav.users'), lcms_engine.admin_users_path %>
+                <%= nav_link t('lcms.engine.admin.nav.access_codes'), lcms_engine.admin_access_codes_path %>
               </ul>
             </li>
 
             <li class="c-header__link">
-              <%= link_to t('lcms.engine.admin.nav.sign_out'), destroy_user_session_path %>
+              <%= link_to t('lcms.engine.admin.nav.sign_out'), lcms_engine.destroy_user_session_path %>
             </li>
           </ul>
         </div>

--- a/app/views/lcms/engine/admin/standards/_form.html.erb
+++ b/app/views/lcms/engine/admin/standards/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @standard, as: :standard, url: admin_standard_path(@standard), html: { class: 'o-standard-form' } do |f| %>
+<%= simple_form_for @standard, as: :standard, url: lcms_engine.admin_standard_path(@standard), html: { class: 'o-standard-form' } do |f| %>
 
   <div class="row o-admin-standard-readonly">
     <label>Name: </label>

--- a/app/views/lcms/engine/admin/standards/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/standards/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for :query, url: :admin_standards, html: { class: 'form-inline well o-admin-standards-search', method: :get } do |f| %>
+<%= simple_form_for :query, url: lcms_engine.admin_standards_path, html: { class: 'form-inline well o-admin-standards-search', method: :get } do |f| %>
 
   <div class='row align-bottom align-justify'>
     <%= f.input :name, label: 'Name', required: false, wrapper_html: { class: 'resource-search-title' } %>

--- a/app/views/lcms/engine/admin/users/_form.html.erb
+++ b/app/views/lcms/engine/admin/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [:admin, @user], html: { id: 'user_form' } do |f| %>
+<%= simple_form_for @user, url: @url.presence || lcms_engine.admin_users_path, html: { id: 'user_form' } do |f| %>
   <%= f.input :id, disabled: true %>
   <%= f.input :name %>
   <%= f.input :email %>

--- a/app/views/lcms/engine/admin/users/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/users/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for :query, url: :admin_users, html: { class: 'form-inline well o-admin-users-search', method: :get } do |f| %>
+<%= simple_form_for :query, url: lcms_engine.admin_users_path, html: { class: 'form-inline well o-admin-users-search', method: :get } do |f| %>
 
   <div class='row align-bottom align-justify'>
     <%= f.input :email, label: false, required: false, placeholder: 'Search by E-mail', wrapper_html: { class: 'o-admin-search-term' } %>

--- a/app/views/lcms/engine/admin/users/index.html.erb
+++ b/app/views/lcms/engine/admin/users/index.html.erb
@@ -7,7 +7,7 @@
 
   <div class="row">
     <div class="flex-pull-right">
-      <%= link_to t('.new_user'), :new_admin_user, class: 'button success' %>
+      <%= link_to t('.new_user'), lcms_engine.new_admin_user_path, class: 'button success' %>
     </div>
     <table class="table">
       <tr>
@@ -27,17 +27,17 @@
       <% @users.each do |user| %>
         <% cache user do %>
           <tr id="user_<%= user.id %>">
-            <td><%= link_to user.id, edit_admin_user_path(user) %>
-            <td><%= link_to user.survey&.fetch('first_name', nil) || user.name, edit_admin_user_path(user) %>
+            <td><%= link_to user.id, lcms_engine.edit_admin_user_path(user) %>
+            <td><%= link_to user.survey&.fetch('first_name', nil) || user.name, lcms_engine.edit_admin_user_path(user) %>
             <td><%= raw user.survey&.fetch('last_name', nil) %>
             <td><%= user.email %>
             <td><%= user.role %>
             <td><%= user.access_code.presence || '-' %>
             <td><%= user.confirmed? ? 'YES' : 'NO' %>
             <td class="u-txt--small"><%= user.created_at.to_s %>
-            <td><%= link_to content_tag(:i, nil, class: 'fas fa-pencil-alt').html_safe, edit_admin_user_path(user), class: 'button small primary' %>
-            <td><%= button_to t('.reset_password_btn'), reset_password_admin_user_path(user), class: 'button small', data: { confirm: t('ui.are_you_sure') }, form_class: 'inline', method: :post %>
-            <td><%= button_to t('ui.delete'), admin_user_path(user), class: 'button small alert', data: { confirm: t('ui.are_you_sure') }, form_class: 'inline', method: :delete %></td>
+            <td><%= link_to content_tag(:i, nil, class: 'fas fa-pencil-alt').html_safe, lcms_engine.edit_admin_user_path(user), class: 'button small primary' %>
+            <td><%= button_to t('.reset_password_btn'), lcms_engine.reset_password_admin_user_path(user), class: 'button small', data: { confirm: t('ui.are_you_sure') }, form_class: 'inline', method: :post %>
+            <td><%= button_to t('ui.delete'), lcms_engine.admin_user_path(user), class: 'button small alert', data: { confirm: t('ui.are_you_sure') }, form_class: 'inline', method: :delete %></td>
           </tr>
         <% end %>
       <% end %>

--- a/spec/controllers/admin/resource_bulk_edit_controller_spec.rb
+++ b/spec/controllers/admin/resource_bulk_edit_controller_spec.rb
@@ -22,7 +22,7 @@ describe Lcms::Engine::Admin::ResourceBulkEditsController do
       grades = resources.flat_map { |r| r.grades.list }
       expect(grades).to_not include('grade 11')
       post :create, params: { ids: ids, resource: { grades: ['grade 11'] } }
-      expect(response).to redirect_to(:admin_resources)
+      expect(response).to redirect_to(lcms_engine(admin_resources_path))
       resources.each do |r|
         expect(r.reload.grades.list).to include('grade 11')
       end

--- a/spec/controllers/admin/resources_controller_spec.rb
+++ b/spec/controllers/admin/resources_controller_spec.rb
@@ -27,7 +27,7 @@ describe Lcms::Engine::Admin::ResourcesController do
     subject { post :update, params: { id: resource.to_param, resource: params } }
 
     context 'with valid params' do
-      it { is_expected.to redirect_to admin_resources_path }
+      it { is_expected.to redirect_to lcms_engine(admin_resources_path) }
 
       it 'passes notice' do
         subject

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -11,6 +11,6 @@ describe Lcms::Engine::Admin::SettingsController do
     expect(Lcms::Engine::Settings[:editing_enabled]).to be true
     patch :toggle_editing_enabled
     expect(Lcms::Engine::Settings[:editing_enabled]).to be false
-    expect(response).to redirect_to(:admin_resources)
+    expect(response).to redirect_to(lcms_engine(admin_resources_path))
   end
 end

--- a/spec/controllers/admin/standards_controller_spec.rb
+++ b/spec/controllers/admin/standards_controller_spec.rb
@@ -60,7 +60,7 @@ describe Lcms::Engine::Admin::StandardsController do
     subject { post :update, params: { id: standard.to_param, standard: params } }
 
     context 'with valid params' do
-      it { is_expected.to redirect_to admin_standards_path }
+      it { is_expected.to redirect_to lcms_engine(admin_standards_path) }
 
       it 'passes notice' do
         subject

--- a/spec/controllers/admin/welcome_controller_spec.rb
+++ b/spec/controllers/admin/welcome_controller_spec.rb
@@ -7,7 +7,7 @@ describe Lcms::Engine::Admin::WelcomeController do
 
   describe 'requires admin user' do
     before { get :index }
-    it { expect(response).to redirect_to new_user_session_path }
+    it { expect(response).to redirect_to lcms_engine(new_user_session_path) }
   end
 
   describe 'allow admin' do

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -49,19 +49,19 @@ xdescribe Lcms::Engine::ResourcesController do
     context 'with id' do
       before { get :show, id: resource.id }
 
-      it { expect(response).to redirect_to("/#{resource.slug}") }
+      it { expect(response).to redirect_to("/lcms-engine#{resource.slug}") }
     end
 
     context 'grade' do
       let(:resource) { create(:resource, :grade) }
       before { get :show, slug: resource.slug }
-      it { expect(response).to redirect_to explore_curriculum_index_path(p: resource.slug, e: 1) }
+      it { expect(response).to redirect_to lcms_engine(explore_curriculum_index_path(p: resource.slug, e: 1)) }
     end
 
     context 'module' do
       let(:resource) { create(:resource, :module) }
       before { get :show, slug: resource.slug }
-      it { expect(response).to redirect_to explore_curriculum_index_path(p: resource.slug, e: 1) }
+      it { expect(response).to redirect_to lcms_engine(explore_curriculum_index_path(p: resource.slug, e: 1)) }
     end
   end
 end

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -14,3 +14,9 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# To prevent Sass errors
+# See https://github.com/rails/sprockets/issues/581
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -57,7 +57,7 @@ feature 'Admin users' do
     click_button 'Save'
 
     user.reload
-    expect(current_path).to eq lcms_engine.edit_admin_user_path(user.id)
+    expect(current_path).to eq lcms_engine.admin_users_path
     expect(page.find('.callout.success').text).to include('saved successfully')
     expect(user.email).to eq "unbounded@#{domain}"
     expect(user.unconfirmed_email).to eq "joe@#{domain}"

--- a/spec/support/routes.rb
+++ b/spec/support/routes.rb
@@ -9,6 +9,10 @@ module Lcms
         included do
           routes { ::Lcms::Engine::Engine.routes }
         end
+
+        def lcms_engine(path)
+          "/lcms-engine#{path}"
+        end
       end
     end
   end


### PR DESCRIPTION
Update calls to the routes to use _mount point_ - that way we can avoid the errors when engine is used in mixed setup with host application. And some parts of the Admin panel is overridden.