### PR TITLE
Fixes link to edit the resource

### DIFF
--- a/app/presenters/lcms/engine/curriculum_presenter.rb
+++ b/app/presenters/lcms/engine/curriculum_presenter.rb
@@ -32,9 +32,9 @@ module Lcms
         when 'subject'
           resource.title
         when 'unit'
-          resource.short_title.upcase
+          resource.short_title&.upcase.presence || 'N/A'
         when 'grade'
-          resource.short_title.capitalize
+          resource.short_title&.capitalize.presence || 'N/A'
         when 'lesson_set'
           "Lesson set #{resource.metadata['lesson_set']}"
         when 'lesson'

--- a/app/views/lcms/engine/admin/resources/index.html.erb
+++ b/app/views/lcms/engine/admin/resources/index.html.erb
@@ -33,7 +33,7 @@
         <% check_box_id = "ids_#{resource.id}" %>
         <td><%= check_box_tag 'ids[]', resource.id, false, class: 'resource-checkbox', id: check_box_id %>
         <td><%= label_tag check_box_id, resource.id, class: 'resource-id-label' %>
-        <td><%= link_to resource.title, [:edit, :admin, resource] %>
+        <td><%= link_to resource.title, lcms_engine.edit_admin_resource_path(resource) %>
         <td class="resource-tag-col"><%= strip_tags resource.teaser %>
         <td class="resource-tag-col"><%= resource.standards.map(&:name).select(&:present?).join(', ') %>
         <td class="resource-tag-col"><%= resource.resource_type %>


### PR DESCRIPTION
Curriculum Editor: fix the error when resource doesn't have _short_title_ value.