### PR TITLE
Remove OOB flow in Google CLI credentials

### DIFF
--- a/app/controllers/lcms/engine/welcome_controller.rb
+++ b/app/controllers/lcms/engine/welcome_controller.rb
@@ -3,7 +3,18 @@
 module Lcms
   module Engine
     class WelcomeController < Lcms::Engine::ApplicationController
+      skip_before_action :authenticate_user!, if: -> { request.path.index('oauth2callback').present? }
+
+      OAUTH_REFERER = 'https://accounts.google.com/'
+      OAUTH_MESSAGE = 'Copy this code and use it to continue authorization'
+
       def index; end
+
+      def oauth2callback
+        head(:not_found) && return unless request.referer == OAUTH_REFERER
+
+        render json: { text: OAUTH_MESSAGE, code: params[:code] }
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,8 @@ Lcms::Engine::Engine.routes.draw do
     resource :batch_reimport, only: %i(new create)
   end
 
+  get '/oauth2callback' => 'welcome#oauth2callback'
+
   get '/*slug' => 'resources#show', as: :show_with_slug
 
   root to: 'welcome#index'

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -29,59 +29,59 @@
 ### AirBrake config
 The project is set up to support Airbrake, if you use it. You can provide an Airbrake ID and key in the config to enable it (Should be omitted for `development`&`test` environments)
 
-|Name|Description|
-|----|-----------|
-|AIR_BRAKE_PROJECT_ID|Project id in the AirBrake service|
-|AIR_BRAKE_PROJECT_KEY|Project key in the AirBrake service|
+| Name                  | Description                         |
+|-----------------------|-------------------------------------|
+| AIR_BRAKE_PROJECT_ID  | Project id in the AirBrake service  |
+| AIR_BRAKE_PROJECT_KEY | Project key in the AirBrake service |
 
 ### Amazon config
 The project uses AWS S3 to store and serve generated PDFs of learning content. You will need to set up an S3 bucket and provide a key and secret here:
 
-|Name|Description|
-|----|-----------|
-|AWS_ACCESS_KEY_ID|Public part of the AWS credentials|
-|AWS_REGION|Name of the region used for AWS service|
-|AWS_SECRET_ACCESS_KEY|Private part of the AWS credentials|
-|AWS_S3_BUCKET_NAME|Bucket used by application to store generated files|
+| Name                  | Description                                         |
+|-----------------------|-----------------------------------------------------|
+| AWS_ACCESS_KEY_ID     | Public part of the AWS credentials                  |
+| AWS_REGION            | Name of the region used for AWS service             |
+| AWS_SECRET_ACCESS_KEY | Private part of the AWS credentials                 |
+| AWS_S3_BUCKET_NAME    | Bucket used by application to store generated files |
 
 ### Google config
 The project uses several Google products, including analytics, OAuth for allowing the application to use Google APIs, and several Google Drive folders.
 
-|Name|Description|
-|----|-----------|
-|GOOGLE_APPLICATION_FOLDER_ID|Id of the Google Drive folder where generated lessons and materials will be placed(It's `0B7` for url like `https://drive.google.com/drive/u/0/folders/0B7/...`)|
-|GOOGLE_APPLICATION_SCRIPT_ID|Id of the Google Script created to post-process generated Google documents. More details can be found [here](google-cloud-platform-setup.md)|
-|GOOGLE_APPLICATION_SCRIPT_FUNCTION|Name of the function to call to start post-processing|
-|GOOGLE_APPLICATION_TEMPLATE_PORTRAIT|Id of the Google document which is a template for portrait materials(can be identified the same way as `GOOGLE_APPLICATION_FOLDER_ID `)|
-|GOOGLE_APPLICATION_TEMPLATE_LANDSCAPE|Id of the Google document which is a template for landscape materials(can be identified the same way as `GOOGLE_APPLICATION_FOLDER_ID `)|
-|GOOGLE_APPLICATION_PREVIEW_FOLDER_ID| Folder ID where preview documents should get placed
-|GOOGLE_API_CLIENT_UPLOAD_RETRIES||
-|GOOGLE_API_CLIENT_UPLOAD_TIMEOUT||
+| Name                                  | Description                                                                                                                                                      |
+|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| GOOGLE_APPLICATION_FOLDER_ID          | Id of the Google Drive folder where generated lessons and materials will be placed(It's `0B7` for url like `https://drive.google.com/drive/u/0/folders/0B7/...`) |
+| GOOGLE_APPLICATION_SCRIPT_ID          | Id of the Google Script created to post-process generated Google documents. More details can be found [here](google-cloud-platform-setup.md)                     |
+| GOOGLE_APPLICATION_SCRIPT_FUNCTION    | Name of the function to call to start post-processing                                                                                                            |
+| GOOGLE_APPLICATION_TEMPLATE_PORTRAIT  | Id of the Google document which is a template for portrait materials(can be identified the same way as `GOOGLE_APPLICATION_FOLDER_ID `)                          |
+| GOOGLE_APPLICATION_TEMPLATE_LANDSCAPE | Id of the Google document which is a template for landscape materials(can be identified the same way as `GOOGLE_APPLICATION_FOLDER_ID `)                         |
+| GOOGLE_APPLICATION_PREVIEW_FOLDER_ID  | Folder ID where preview documents should get placed                                                                                                              |
+| GOOGLE_API_CLIENT_UPLOAD_RETRIES      ||     |
+| GOOGLE_API_CLIENT_UPLOAD_TIMEOUT      ||     |
 
 ### Miscellaneous settings
-|Name|Description|
-|----|-----------|
-|APP_NAME|The title which will be shown in the page title and in other places. Something like `OpenSciEd LCMS`|
-|BITLY_API_TOKEN|Token of the Bitly service|
-|RESQUE_NAMESPACE|Value is used to separate data stored in Redis when the same redis server is used by multiple environments|
-|PUPPETEER_TIMEOUT|Default is 30 sec|
-|WORKERS_COUNT|Used on the servers. Specifies the number of workers to be started|
-|ELASTICSEARCH_ADDRESS|Elasticsearch server address|
+| Name                  | Description                                                                                                |
+|-----------------------|------------------------------------------------------------------------------------------------------------|
+| APP_NAME              | The title which will be shown in the page title and in other places. Something like `OpenSciEd LCMS`       |
+| BITLY_API_TOKEN       | Token of the Bitly service                                                                                 |
+| RESQUE_NAMESPACE      | Value is used to separate data stored in Redis when the same redis server is used by multiple environments |
+| PUPPETEER_TIMEOUT     | Default is 30 sec                                                                                          |
+| WORKERS_COUNT         | Used on the servers. Specifies the number of workers to be started                                         |
+| ELASTICSEARCH_ADDRESS | Elasticsearch server address                                                                               |
 
 Obs: if you're setting a local dev machine on OSX and getting small fonts when generating pdfs, try downgrading wkhtmltopdf to `0.12.3`
 
 ### PDF related config
-|Name|Description|
-|----|-----------|
-|ENABLE_BASE64_CACHING|Turns on/off caching of assets used for PDF generation (`true` by default, recommended as `false` for local env)|
-|NODE_ENV|We're using puppeteer(npm package) for PDF Generation, should be set as `production` for other env than local|
-|WKHTMLTOPDF_PATH|Path to the [wkhtmltopdf](https://wkhtmltopdf.org) binary. Default to `/usr/local/bin/wkhtmltopdf`. Will be removed when we will be certain on puppeteer|
+| Name                  | Description                                                                                                                                              |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ENABLE_BASE64_CACHING | Turns on/off caching of assets used for PDF generation (`true` by default, recommended as `false` for local env)                                         |
+| NODE_ENV              | We're using puppeteer(npm package) for PDF Generation, should be set as `production` for other env than local                                            |
+| WKHTMLTOPDF_PATH      | Path to the [wkhtmltopdf](https://wkhtmltopdf.org) binary. Default to `/usr/local/bin/wkhtmltopdf`. Will be removed when we will be certain on puppeteer |
 
 ### Postgres config
-|Name|
-|----|
-|POSTGRESQL_ADDRESS|
-|POSTGRESQL_DATABASE|
-|POSTGRESQL_USERNAME|
-|POSTGRESQL_PASSWORD|
-|POSTGRESQL_PORT|
+| Name                |
+|---------------------|
+| POSTGRESQL_ADDRESS  |
+| POSTGRESQL_DATABASE |
+| POSTGRESQL_USERNAME |
+| POSTGRESQL_PASSWORD |
+| POSTGRESQL_PORT     |

--- a/docs/google-cloud-platform-setup.md
+++ b/docs/google-cloud-platform-setup.md
@@ -1,3 +1,5 @@
+# Google Cloud Platform setup
+
 An application calls the Google Application Script in order to post-process generated lesson materials. Instructions below contains all the necessary steps need to set up the integration.
 
 All environment variables and user names provided here have been set up to automate deployment on [Cloud66](https://www.cloud66.com) service stacks. If you plan to use another service provider please change all the variables accordingly.
@@ -7,22 +9,28 @@ All environment variables and user names provided here have been set up to autom
 
 ## Set up
 
-1. Login to google (all google docs will be saved under this account)
+### Login to google
 
-2. Create project (i.e. LCMS-dev) at [google cloud](https://console.cloud.google.com)
+All google docs will be saved under this account. Also, this Google Account should have access to all source documents which will be imported into the system.
 
-3. Enable Google Drive API, Google Apps Script Execution API for that [project](https://console.cloud.google.com/apis/library)
+### Create project
 
-4. Set up google auth
+Name it whatever you like, i.e. LCMS-dev at [google cloud](https://console.cloud.google.com)
+
+### Enable Google API
+
+Enable Google Drive API, Google Apps Script Execution API for that [project](https://console.cloud.google.com/apis/library)
+
+### Set up google auth
 
 #### Credentials
 
 Create credentials:
   - type oAuth Client ID
-  - Application type: Other,
-  - Aplication Name: up to you, i.e. lcms-cli-dev
+  - Application type: Web Application,
+  - Application Name: up to you, i.e. lcms-cli-dev
 
-Download client secret JSON file.
+Download credentials JSON file.
 
 ###### Local development
 
@@ -59,10 +67,11 @@ If you generate token on a remote server, then make sure you're executing comman
 $ sudo -i -u cloud66-user
 ```
 
-Run rake task. You will be asked to go by link, give app permissions and paste code into the terminal
+Run rake task providing the domain name which is registered as _Authorized redirect URIs_ in Google OAuth client.
+You will be asked to go by link, give app permissions and paste code into the terminal
 
 ```bash
-$ bundle exec rake google:setup_auth
+$ bundle exec rake google:setup_auth["https://example.com"]
 ```
 
 This will create `config/google/app_token.yaml`. Change the ownership of the `app_token.yaml` otherwise it will not be accessible for the application:
@@ -73,23 +82,28 @@ $ chown cloud66-user:app_writers app_token.yaml
 $ sudo chmod g+w app_token.yaml
 ```
 
-5. Add script
+#### Add Google App script
+
 - go to https://www.google.com/script/start/
 - copy-paste content of `config/scripts/Code.gs` there and save
 - at top menu Resources->Cloud Platform Project set project from step 2 (you need to paste *project number*)
 - at top menu Publish->Deploy As API Executable set version v1, access Only myself
-- save Current API ID somewhere, click Close on that annoying window (update will not close it)
+- save Current API ID somewhere (wil be used for _GOOGLE_APPLICATION_SCRIPT_ID_), click Close on that annoying window (update will not close it)
 - choose any function and run it, it'll request permissions - grant them (there will be security warnings, just ignore them)
 
-6. Create folder (all materials will be saved there) on Google Drive, give view only to all by link, keep folder id (last part of url), copy to the root [LANDSCAPE](https://docs.google.com/document/d/1pXQDNKYOJYT6OTPnp8gsTWAydg5B9GTRibaWspmX4oE), [PORTRAIT](https://docs.google.com/document/d/1ijuZhGQXkPBxcZT4DRyNVY-qmI0xyVvSzVFqckOpsCc) templates and keep their IDs.
+### Create special folder in Google Drive
 
-7. Update corresponding env-file in the project
+All materials will be saved there. Give view only to all by link, keep folder id (last part of url) for _GOOGLE_APPLICATION_FOLDER_ID_,
+copy to the root of the this folder these documents and keep their IDs for (_GOOGLE_APPLICATION_TEMPLATE_LANSCAPE_, _GOOGLE_APPLICATION_TEMPLATE_PORTRAIT_):
+- [LANDSCAPE](https://docs.google.com/document/d/1pXQDNKYOJYT6OTPnp8gsTWAydg5B9GTRibaWspmX4oE)
+- [PORTRAIT](https://docs.google.com/document/d/1ijuZhGQXkPBxcZT4DRyNVY-qmI0xyVvSzVFqckOpsCc)
 
+### Update corresponding env-file in the project
 ```
-GOOGLE_APPLICATION_FOLDER_ID=saved from step 6
-GOOGLE_APPLICATION_SCRIPT_ID=saved id from step 5
-GOOGLE_APPLICATION_TEMPLATE_PORTRAIT=saved from step 6
-GOOGLE_APPLICATION_TEMPLATE_LANSCAPE=saved from step 6
+GOOGLE_APPLICATION_FOLDER_ID=
+GOOGLE_APPLICATION_SCRIPT_ID=
+GOOGLE_APPLICATION_TEMPLATE_PORTRAIT=
+GOOGLE_APPLICATION_TEMPLATE_LANSCAPE=
 ```
 
 ## How to update Google Application Script

--- a/lib/tasks/google.rake
+++ b/lib/tasks/google.rake
@@ -4,22 +4,37 @@ require 'googleauth'
 require 'googleauth/stores/file_token_store'
 require 'lt/google/api/auth/cli'
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
-
 namespace :google do
-  desc 'set up google credentials'
-  task setup_auth: :environment do
+  desc 'Set up google credentials. Specify `domain` argument which will be used as a base for redirect URI'
+  task :setup_auth, [:domain] => [:environment] do |_task, args|
     service = ::Lt::Google::Api::Auth::Cli.new
-    if service.credentials.nil?
-      authorizer = service.authorizer
-      url = authorizer.get_authorization_url(base_url: OOB_URI)
-      puts "Open \n>> #{url}\n in your browser and enter the resulting code:"
-      code = $stdin.gets.strip
-      authorizer.get_and_store_credentials_from_code(
-        user_id: ::Lt::Google::Api::Auth::Cli::USER_ID, code: code, base_url: OOB_URI
-      )
-    else
-      puts 'No need in action, everything is already set up'
+
+    # Check if there is existing auth token
+    if service.credentials.present?
+      puts <<~TEXT
+        Auth token already exists. Do you want to request new one?
+        Type Y for Yes, N for No
+      TEXT
+      next unless $stdin.gets.to_s.strip.downcase == 'y'
     end
+
+    authorizer = service.authorizer
+    url = authorizer.get_authorization_url(base_url: args[:domain])
+
+    puts <<~TEXT
+      Open this URL in your browser:
+      >>>>>
+      #{url}
+      >>>>>
+      Copy auth code and paste it below.
+    TEXT
+
+    code = $stdin.gets.to_s.strip
+
+    authorizer.get_and_store_credentials_from_code(
+      user_id: ::Lt::Google::Api::Auth::Cli::USER_ID,
+      code: code,
+      base_url: args[:domain]
+    )
   end
 end

--- a/spec/controllers/admin/welcome_controller_spec.rb
+++ b/spec/controllers/admin/welcome_controller_spec.rb
@@ -5,17 +5,19 @@ require 'rails_helper'
 describe Lcms::Engine::Admin::WelcomeController do
   let(:user) { create :admin }
 
-  describe 'requires admin user' do
-    before { get :index }
-    it { expect(response).to redirect_to lcms_engine(new_user_session_path) }
-  end
-
-  describe 'allow admin' do
-    before do
-      sign_in user
-      get :index
+  describe 'GET index' do
+    context 'requires admin user' do
+      before { get :index }
+      it { expect(response).to redirect_to lcms_engine(new_user_session_path) }
     end
 
-    it { expect(response).to be_successful }
+    context 'allow admin' do
+      before do
+        sign_in user
+        get :index
+      end
+
+      it { expect(response).to be_successful }
+    end
   end
 end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lcms::Engine::WelcomeController do
+  #
+  # In the Host application should be a proxy which will redirect
+  # request inside mounted engine
+  #
+  describe 'GET oauth2callback' do
+    let(:code) { Faker::Lorem.words.join }
+
+    before { request.env['HTTP_REFERER'] = Lcms::Engine::WelcomeController::OAUTH_REFERER }
+
+    subject { get :oauth2callback, params: { code: code } }
+
+    it 'skips authorization' do
+      subject
+      expect(response).to be_successful
+    end
+
+    it 'renders passed in params as JSON' do
+      subject
+      result = JSON.parse(response.body)
+      expect(result['text']).to eq Lcms::Engine::WelcomeController::OAUTH_MESSAGE
+      expect(result['code']).to eq code
+    end
+
+    context 'when referer is not a Google service' do
+      before { request.env['HTTP_REFERER'] = 'test.com' }
+
+      it 'returns 404' do
+        subject
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   mount Lcms::Engine::Engine => '/lcms-engine'
   root to: redirect('/lcms-engine/')
 
+  get '/oauth2callback', to: redirect(path: '/lcms-engine/oauth2callback')
+
   # Used for testing only
   direct(:document) { '/' }
   direct(:material) { '/' }


### PR DESCRIPTION
1. Update `google:setup_auth` rake task

Now task conforms with new OAuth application type (now it is Web Application). Also it allows to re-request auth token in case there is already one.

2.Introduce new `/oauth2callback` endpoint.

Accept a request to this endpoint only from `https://accounts.google.com/` referer.