### PR TITLE
Ruby v2.7.7 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.4
+FROM ruby:2.7.7
 
 ENV APP_PATH /app/
 ENV LANG C.UTF-8
@@ -13,12 +13,10 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Add codebase
-ADD . $APP_PATH
+COPY . $APP_PATH
 
 # Install gems
-ADD lcms-engine.gemspec $APP_PATH
-ADD Gemfile* $APP_PATH
-RUN gem install bundler:2.3.26 \
+RUN gem install bundler:2.4.8 \
     && bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3 \
     && rm -rf /usr/local/bundle/cache/*.gem \
     && find /usr/local/bundle/gems/ -name "*.c" -delete \

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ $ brew cask install chromedriver
 #### Using Docker
 
 Launch the containers
-```sh
+```shell
 $ docker build -t lcms-engine .
 $ docker compose start
 $ docker compose exec app sh -c 'bin/rails db:create'
@@ -207,8 +207,13 @@ $ docker compose exec db sh -c "psql -U postgres -d template1 -c 'CREATE EXTENSI
 ```
 
 Start the specs
-```sh
+```shell
 $ docker compose exec app sh -c 'bundle exec rspec'
+```
+
+In case you need to rebuild the image, use buildx command to create multi-arch image and push it to the registry
+```shell
+docker buildx build --platform linux/arm64/v8,linux/amd64 -t learningtapestry/lcms-engine --push .
 ```
 
 ## License

--- a/lcms-engine.gemspec
+++ b/lcms-engine.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name = 'lcms-engine'
   s.version = Lcms::Engine::VERSION
   s.authors = ['Alexander Kuznetsov', 'Abraham Sánchez', 'Rômulo Saksida']
-  s.email = %w(alexander@learningtapestry.com abraham@learningtapestry.com rm@learningtapestry.com)
+  s.email = %w(paranoic.san@gmail.com abraham@learningtapestry.com rm@learningtapestry.com)
   s.homepage = 'https://github.com/learningtapestry/lcms-engine'
   s.summary = 'Rails engine for LCMS applications'
   s.description = 'Implements common components and features for Rails-based LCMS systems'


### PR DESCRIPTION
1. Bump ruby to 2.7.7
2. Add an instruction to build multi-arch Docker image.