### PR TITLE
[BREAKING] Refactor query handling in admin controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [BREAKING] Refactor query handling in admin controllers - [@paranoicsan](https://github.com/paranoicsan)
 - [BREAKING] Rename `import_status_for` to `import_status_for_nested` inside `Lcms::Engine::NestedReimportable` - [@paranoicsan](https://github.com/paranoicsan)
 - Normalize metadata search in Resource model - [@paranoicsan](https://github.com/paranoicsan)
 

--- a/app/controllers/concerns/lcms/engine/queryable.rb
+++ b/app/controllers/concerns/lcms/engine/queryable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Lcms
+  module Engine
+    module Queryable
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :set_query_params
+      end
+
+      def set_query_params
+        @query_params = params[:query]&.permit(*QUERY_ATTRS_KEYS, QUERY_ATTRS_NESTED) || {}
+      end
+
+      def query_struct(attrs)
+        Struct.new(*QUERY_ATTRS_KEYS, keyword_init: true).new(attrs.to_h)
+      end
+    end
+  end
+end

--- a/app/controllers/lcms/engine/admin/standards_controller.rb
+++ b/app/controllers/lcms/engine/admin/standards_controller.rb
@@ -4,8 +4,16 @@ module Lcms
   module Engine
     module Admin
       class StandardsController < AdminController
+        include Lcms::Engine::Queryable
+
         before_action :find_standard, except: %i(import index)
-        before_action :set_query_params
+        before_action :set_query_params # from Lcms::Engine::Queryable
+
+        QUERY_ATTRS = %i(
+          name
+        ).freeze
+        QUERY_ATTRS_NESTED = {}.freeze
+        QUERY_ATTRS_KEYS = QUERY_ATTRS + QUERY_ATTRS_NESTED.keys
 
         def edit; end
 
@@ -20,7 +28,7 @@ module Lcms
         end
 
         def index
-          @query = OpenStruct.new @query_params # rubocop:disable Style/OpenStructUse
+          @query = query_struct(@query_params)
 
           scope = Standard.order('id')
           scope = scope.search_by_name(@query.name) if @query.name.present?
@@ -40,10 +48,6 @@ module Lcms
 
         def find_standard
           @standard = Standard.find(params[:id])
-        end
-
-        def set_query_params
-          @query_params = params[:query]&.permit(:name) || {}
         end
 
         def standard_form_params

--- a/app/controllers/lcms/engine/admin/users_controller.rb
+++ b/app/controllers/lcms/engine/admin/users_controller.rb
@@ -4,11 +4,19 @@ module Lcms
   module Engine
     module Admin
       class UsersController < AdminController
+        include Lcms::Engine::Queryable
+
         before_action :find_user, except: %i(index new create)
-        before_action :set_query_params
+        before_action :set_query_params # from Lcms::Engine::Queryable
+
+        QUERY_ATTRS = %i(
+          access_code
+          email
+        ).freeze
+        QUERY_ATTRS_KEYS = QUERY_ATTRS
 
         def index
-          @query = OpenStruct.new @query_params # rubocop:disable Style/OpenStructUse
+          @query = query_struct(@query_params)
           @users = users(@query)
         end
 
@@ -52,10 +60,6 @@ module Lcms
 
         def find_user
           @user = User.find(params[:id])
-        end
-
-        def set_query_params
-          @query_params = params[:query]&.permit(:access_code, :email) || {}
         end
 
         def user_params

--- a/app/queries/lcms/engine/admin_documents_query.rb
+++ b/app/queries/lcms/engine/admin_documents_query.rb
@@ -21,16 +21,17 @@ module Lcms
       private
 
       def apply_filters # rubocop:todo Metrics/AbcSize,  Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        @scope = q.inactive == '1' ? @scope.unscoped : @scope.actives
-        @scope = @scope.failed if q.only_failed == '1'
-        @scope = @scope.filter_by_term(q.search_term) if q.search_term.present?
+        @scope = q.respond_to?(:inactive) && q.inactive == '1' ? @scope.unscoped : @scope.actives
+        @scope = @scope.failed if q.respond_to?(:only_failed) && q.only_failed == '1'
+        @scope = @scope.filter_by_term(q.search_term) if q.respond_to?(:search_term) && q.search_term.present?
         @scope = @scope.filter_by_subject(q.subject) if q.subject.present?
-        @scope = @scope.filter_by_grade(q.grade) if q.grade.present?
-        @scope = @scope.where_grade(q.grades&.compact) if Array.wrap(q.grades).reject(&:blank?).present?
+        @scope = @scope.filter_by_grade(q.grade) if q.respond_to?(:grade) && q.grade.present?
+        @scope = @scope.where_grade(q.grades&.compact) \
+          if q.respond_to?(:grades) && Array.wrap(q.grades).reject(&:blank?).present?
         @scope = @scope.filter_by_module(q.module) if q.module.present?
         @scope = @scope.filter_by_unit(q.unit) if q.unit.present?
-        @scope = @scope.with_broken_materials if q.broken_materials == '1'
-        @scope = @scope.with_updated_materials if q.reimport_required == '1'
+        @scope = @scope.with_broken_materials if q.respond_to?(:broken_materials) && q.broken_materials == '1'
+        @scope = @scope.with_updated_materials if q.respond_to?(:reimport_required) && q.reimport_required == '1'
         @scope
       end
 

--- a/app/queries/lcms/engine/base_query.rb
+++ b/app/queries/lcms/engine/base_query.rb
@@ -10,7 +10,8 @@ module Lcms
       # query : query params (Hash or OpenStruct)
       # pagination : pagination params, if pagination is nil whe return all results
       def initialize(query, pagination = nil)
-        @q = OpenStruct.new(query) # rubocop:disable Style/OpenStructUse
+        # query is a type of `Struct` with pre-defined and pre-populated fields
+        @q = query
         @pagination = pagination
       end
 

--- a/app/views/lcms/engine/admin/batch_reimports/_search_form.html.erb
+++ b/app/views/lcms/engine/admin/batch_reimports/_search_form.html.erb
@@ -5,7 +5,7 @@
                   collection: Lcms::Engine::Resource::SUBJECTS, label_method: :humanize %>
     </div>
     <div class="col">
-      <%= f.input :grades, collection: Lcms::Engine::Grades.grades,
+      <%= f.input :grade, collection: Lcms::Engine::Grades.grades,
                   label: 'Grade', label_method: :humanize, required: false, wrapper: false %>
     </div>
     <div class="col">


### PR DESCRIPTION

Possibly can break the inherited controllers. Apply changes carefully.

Unified query handling by extracting common query logic into `Lcms::Engine::Queryable` concern. Updated controllers and views to use the new concern for setting query parameters and constructing query structs, improving code maintainability and reducing redundancy.

This allows us to get rid of OpenStruct usage completely.