### PR TITLE
Expand Ruby version support to 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump Rails to 7.2.2.1
+- Ruby 3.5 set as a top-level border for dependency 
+- Bump Rails to 7.2.2.1§
 - Bump ruby to 3.3.9
 - Bump ruby to 3.3.8
 - Bump ruby to 3.2.9

--- a/lcms-engine.gemspec
+++ b/lcms-engine.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,bin,config,db,docs,lib,public,sig,templates, vendor}/**/*', 'LICENSE', 'README.md',
                 'lcms-engine.gemspec', 'Gemfile', 'Gemfile.lock']
 
-  s.required_ruby_version = '~> 3.2', '< 3.4'
+  s.required_ruby_version = '~> 3.2', '< 3.5'
 
   s.add_dependency 'activejob-retry', '~> 0.6.3'
   s.add_dependency 'active_model_serializers', '~> 0.10.10'


### PR DESCRIPTION
Expanded the supported Ruby version range to include Ruby 3.5, ensuring compatibility with the latest version. 
