### PR TITLE
[hotfix] fixed passing args

### DIFF
--- a/lib/doc_template/tables/base.rb
+++ b/lib/doc_template/tables/base.rb
@@ -7,8 +7,8 @@ module DocTemplate
 
       attr_reader :errors, :data
 
-      def self.parse(fragment, *args)
-        new.parse(fragment, args)
+      def self.parse(fragment, *)
+        new.parse(fragment, *)
       end
 
       def self.flatten_table(table)


### PR DESCRIPTION
This pull request makes a minor update to the `Base` class in `lib/doc_template/tables/base.rb` by simplifying the argument forwarding in the `self.parse` method. The change replaces manual argument unpacking with the Ruby splat operator for more idiomatic and flexible code.